### PR TITLE
fix commitLongestPath off-by-one

### DIFF
--- a/node/consensus/ceremony/consensus_frames.go
+++ b/node/consensus/ceremony/consensus_frames.go
@@ -810,7 +810,7 @@ func (e *CeremonyDataClockConsensusEngine) commitLongestPath(
 			}
 
 			runningFrames = [][]*protobufs.ClockFrame{
-				{nextRunningFrames[0][currentDepth+1]},
+				{nextRunningFrames[0][currentDepth]},
 			}
 			currentDepth = 0
 		} else {


### PR DESCRIPTION
When commitLongestPath is run in some circumstances, every other frame is skipped


{"level":"info","ts":1697346594.2224607,"caller":"ceremony/consensus_frames.go:1029","msg":"selecting leader"}
{"level":"info","ts":1697346594.645416,"caller":"ceremony/consensus_frames.go:618","msg":"searching from committed frame","frame_number":0}
{"level":"info","ts":1697346594.6454806,"caller":"ceremony/consensus_frames.go:635","msg":"ranging over candidates for frame","frame_number":0}
{"level":"info","ts":1697346594.9158735,"caller":"ceremony/consensus_frames.go:689","msg":"setting longest path cursor to frame","frame_number":1}
{"level":"info","ts":1697346594.916715,"caller":"ceremony/consensus_frames.go:696","msg":"adding candidate","frame_number":1}
{"level":"info","ts":1697346594.9441156,"caller":"ceremony/consensus_frames.go:849","msg":"not ready to commit","forks":1,"current_depth":0}
{"level":"info","ts":1697346594.9441257,"caller":"ceremony/consensus_frames.go:635","msg":"ranging over candidates for frame","frame_number":1}
{"level":"info","ts":1697346595.1244864,"caller":"ceremony/consensus_frames.go:689","msg":"setting longest path cursor to frame","frame_number":2}
{"level":"info","ts":1697346595.1245453,"caller":"ceremony/consensus_frames.go:696","msg":"adding candidate","frame_number":2}
{"level":"info","ts":1697346595.1246226,"caller":"ceremony/consensus_frames.go:717","msg":"consensus found, committing frames","commit_depth":2}
{"level":"info","ts":1697346595.1246326,"caller":"ceremony/consensus_frames.go:729","msg":"committing candidate","frame_number":1,"prover":"xxxxxx"}
{"level":"info","ts":1697346595.7708964,"caller":"ceremony/consensus_frames.go:635","msg":"ranging over candidates for frame","frame_number":2}
{"level":"info","ts":1697346596.0338013,"caller":"ceremony/consensus_frames.go:689","msg":"setting longest path cursor to frame","frame_number":3}
{"level":"info","ts":1697346596.0338585,"caller":"ceremony/consensus_frames.go:696","msg":"adding candidate","frame_number":3}
{"level":"info","ts":1697346596.033956,"caller":"ceremony/consensus_frames.go:849","msg":"not ready to commit","forks":1,"current_depth":0}
{"level":"info","ts":1697346596.0339627,"caller":"ceremony/consensus_frames.go:635","msg":"ranging over candidates for frame","frame_number":3}
{"level":"info","ts":1697346596.1717389,"caller":"ceremony/consensus_frames.go:689","msg":"setting longest path cursor to frame","frame_number":4}
{"level":"info","ts":1697346596.1718082,"caller":"ceremony/consensus_frames.go:696","msg":"adding candidate","frame_number":4}
{"level":"info","ts":1697346596.1719935,"caller":"ceremony/consensus_frames.go:717","msg":"consensus found, committing frames","commit_depth":2}
{"level":"info","ts":1697346596.1720068,"caller":"ceremony/consensus_frames.go:729","msg":"committing candidate","frame_number":3,"prover":"xxxxxx"}