### PR TITLE
Add CLI flag to print peer id from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ If you do not, or have already run the above, run:
 
     GOEXPERIMENT=arenas go run ./...
 
+## Peer ID
+
+In order to find the peer id of a running node, execute the following command from the `node/` folder:
+
+    GOEXPERIMENT=arenas go run ./... --peer-id
+
+The peer id will be printed to stdout.
+
 ## EXPERIMENTAL – gRPC/REST Support
 
 If you want to enable gRPC/REST, add the following entries to your config.yml:

--- a/node/main.go
+++ b/node/main.go
@@ -38,10 +38,26 @@ var (
 		false,
 		"starts the node in database console mode",
 	)
+
+	peerId = flag.Bool(
+		"peer-id",
+		false,
+		"print the peer id to stdout from the config and exit",
+	)
 )
 
 func main() {
 	flag.Parse()
+
+	if *peerId {
+		config, err := config.LoadConfig(*configDirectory, "")
+		if err != nil {
+			panic(err)
+		}
+
+		printPeerID(config.P2P)
+		return
+	}
 
 	if *importPrivKey != "" {
 		config, err := config.LoadConfig(*configDirectory, *importPrivKey)


### PR DESCRIPTION
Adds a CLI flag to print the peer id from a config file and then exit. Useful for finding the peer id of a running node.

Tested with the config file of node running the latest ceremony client.

Example usage from the `node/` directory: 

```
> GOEXPERIMENT=arenas go run ./... --peer-id
Peer ID: Qme5PeqPSNRAvgWYbKoW9yy8S9tUwx1RBGaJ4ByE1a4rnu
```