### PR TITLE
v1.2.2 - sneaky sync troubles

### DIFF
--- a/node/app/db_console.go
+++ b/node/app/db_console.go
@@ -818,11 +818,11 @@ func logoVersion(width int) string {
 		out += "                     #######################################        ########\n"
 		out += "                          #############################                ##\n"
 		out += " \n"
-		out += "                         Quilibrium Node - v1.2.1 – Dawn\n"
+		out += "                         Quilibrium Node - v1.2.2 – Dawn\n"
 		out += " \n"
 		out += "                                   DB Console\n"
 	} else {
-		out = "Quilibrium Node - v1.2.1 – Dawn - DB Console\n"
+		out = "Quilibrium Node - v1.2.2 – Dawn - DB Console\n"
 	}
 	return out
 }

--- a/node/consensus/ceremony/peer_messaging.go
+++ b/node/consensus/ceremony/peer_messaging.go
@@ -85,7 +85,7 @@ func (e *CeremonyDataClockConsensusEngine) GetCompressedSyncFrames(
 			)
 			if err != nil {
 				from = 1
-				e.logger.Info("peer fully out of sync, rewinding sync head to start")
+				e.logger.Debug("peer fully out of sync, rewinding sync head to start")
 				break
 			}
 
@@ -95,8 +95,8 @@ func (e *CeremonyDataClockConsensusEngine) GetCompressedSyncFrames(
 				parent,
 			)
 			if err != nil {
-				from = 1
-				e.logger.Info("peer fully out of sync, rewinding sync head to start")
+				from = frame.FrameNumber - 16
+				e.logger.Debug("peer fully out of sync, rewinding sync head to min")
 				break
 			}
 
@@ -167,6 +167,7 @@ func (e *CeremonyDataClockConsensusEngine) decompressAndStoreCandidates(
 		e.peerMapMx.Lock()
 		if _, ok := e.peerMap[string(peerId)]; ok {
 			e.uncooperativePeersMap[string(peerId)] = e.peerMap[string(peerId)]
+			e.uncooperativePeersMap[string(peerId)].timestamp = time.Now().UnixMilli()
 			delete(e.peerMap, string(peerId))
 		}
 		e.peerMapMx.Unlock()

--- a/node/consensus/consensus_engine.go
+++ b/node/consensus/consensus_engine.go
@@ -59,5 +59,5 @@ func GetMinimumVersion() []byte {
 }
 
 func GetVersion() []byte {
-	return []byte{0x01, 0x02, 0x01}
+	return []byte{0x01, 0x02, 0x02}
 }

--- a/node/main.go
+++ b/node/main.go
@@ -249,5 +249,5 @@ func printLogo() {
 
 func printVersion() {
 	fmt.Println(" ")
-	fmt.Println("                         Quilibrium Node - v1.2.1 – Dawn")
+	fmt.Println("                         Quilibrium Node - v1.2.2 – Dawn")
 }


### PR DESCRIPTION
libp2p has some quirks related to peer info synchronization, including delays on address resolution. Our expectations didn't line up correctly with its behavior, and so there was cases where high frame peers could get stuck in a loop where their state (as other nodes see it) is wrong, can't be synced with, but might even top out the list, making it lead to long periods where syncs will fail for a node (waiting for others to catch up). This works around those expectations.