### PR TITLE
add basic Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM golang:1.20-alpine
 
+LABEL org.opencontainers.image.title="Quilibrium Network Node"
+LABEL org.opencontainers.image.description="Quilibrium is a decentralized alternative to platform as a service providers."
+LABEL org.opencontainers.image.vendor=Quilibrium
+LABEL org.opencontainers.image.url=https://quilibrium.com/
+LABEL org.opencontainers.image.documentation=https://quilibrium.com/docs
+
 ENV GOEXPERIMENT=arenas
 
 WORKDIR /opt/ceremonyclient

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-alpine
+FROM golang:1.20.14-alpine3.19
 
 LABEL org.opencontainers.image.title="Quilibrium Network Node"
 LABEL org.opencontainers.image.description="Quilibrium is a decentralized alternative to platform as a service providers."

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.20
+
+ENV GOEXPERIMENT=arenas
+
+WORKDIR /opt/ceremonyclient
+
+COPY . . 
+
+WORKDIR /opt/ceremonyclient/node
+
+RUN go mod download && go mod verify
+
+CMD ["go", "run", "./..."]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.20-alpine
 
 ENV GOEXPERIMENT=arenas
 
@@ -9,6 +9,6 @@ COPY . .
 WORKDIR /opt/ceremonyclient/node
 
 RUN go mod download && go mod verify
+RUN go build ./...
 
-CMD ["go", "run", "./..."]
-
+ENTRYPOINT ["go", "run", "./..."]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.8"
+
+name: quilibrium
+
+volumes:
+  config:
+
+services:
+  node:
+    build: ./
+    image: quilibrium
+    restart: always
+    volumes:
+      - config:/opt/ceremonyclient/node/.config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,6 @@ version: "3.8"
 
 name: quilibrium
 
-volumes:
-  config:
-
 services:
   node:
     build: ./
@@ -15,7 +12,7 @@ services:
       - '127.0.0.1:8337:8337/tcp' # gRPC
       - '127.0.0.1:8338:8338/tcp' # REST
     volumes:
-      - config:/opt/ceremonyclient/node/.config
+      - ./.config:/opt/ceremonyclient/node/.config
     logging:
       driver: "json-file"
       options:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,9 @@ services:
     build: ./
     image: quilibrium
     restart: always
+    ports:
+      - '8336:8336/udp' # p2p
+      - '127.0.0.1:8337:8337/tcp' # gRPC
+      - '127.0.0.1:8338:8338/tcp' # REST
     volumes:
       - config:/opt/ceremonyclient/node/.config

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,8 @@ services:
       - '127.0.0.1:8338:8338/tcp' # REST
     volumes:
       - config:/opt/ceremonyclient/node/.config
+    logging:
+      driver: "json-file"
+      options:
+        max-file: "5"
+        max-size: 2048m


### PR DESCRIPTION
Adding both a `Dockerfile` and `docker-compose.yml`  files that allow you to easily create an image and run it.

```shell
docker build -t quilibrium -t quilibrium:1.2.5 .
docker compose up -d
```

Notes:

* a golang 1.20 base image, based on Alpine linux is used
* a docker volume is used for the `node/.config` folder (and this includes the nested `storage` subfolder)
* the p2p port 8336/udp is mapped to the host, all interfaces
* the gRPC and REST ports 8337/tcp and 8338/tcp are mapped to host, localhost interface only

In order to drop into a shell inside the container:
```shell
docker compose exec -it node sh
```

Future work:

* set defaults for `listenRESTMultiaddr` and `listenGrpcMultiaddr`
* add `HEALTHCHECK` to the image
* add monitoring related services (Prometheus, Grafana, etc) to the compose