### PR TITLE
add env var based default addresses for RPC endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ services:
     build: ./
     image: quilibrium
     restart: always
+    environment:
+      - DEFAULT_LISTEN_GRPC_MULTIADDR=/ip4/0.0.0.0/tcp/8337
+      - DEFAULT_LISTEN_REST_MULTIADDR=/ip4/0.0.0.0/tcp/8338
     ports:
       - '8336:8336/udp' # p2p
       - '127.0.0.1:8337:8337/tcp' # gRPC

--- a/node/config/config.go
+++ b/node/config/config.go
@@ -137,6 +137,11 @@ func LoadConfig(configPath string, proverKey string) (*Config, error) {
 
 		config.Key.KeyStoreFile.EncryptionKey = hex.EncodeToString(keystoreKey)
 
+		if multiAddr := os.Getenv("DEFAULT_LISTEN_GRPC_MULTIADDR"); multiAddr != "" {
+			config.ListenGRPCMultiaddr = multiAddr
+			config.ListenRestMultiaddr = os.Getenv("DEFAULT_LISTEN_REST_MULTIADDR")
+		}
+
 		fmt.Println("Saving config...")
 		if err = SaveConfig(configPath, config); err != nil {
 			panic(err)


### PR DESCRIPTION
When writing a default `config.yml` look for a `DEFAULT_LISTEN_GRPC_MULTIADDR` env var and if set use it's value to set the initial `listenGRPCMultiaddr`.

Only if `DEFAULT_LISTEN_GRPC_MULTIADDR` is present then also `DEFAULT_LISTEN_REST_MULTIADDR` will be used to set `listenRestMultiaddr`.

This change will allow docker-compose.yml to set `listenGRPCMultiaddr` and `listenRestMultiaddr`.

Related docker compose PR: https://github.com/QuilibriumNetwork/ceremonyclient/pull/46