### PR TITLE
fix poor_man_cd race conditions

### DIFF
--- a/node/poor_mans_cd.sh
+++ b/node/poor_mans_cd.sh
@@ -2,19 +2,39 @@
 
 start_process() {
     GOEXPERIMENT=arenas go run ./... &
-    process_pid=$!
-    child_process_pid=$(pgrep -P $process_pid)
+    local process_pid=$!
+    local child_process_pid=$(pgrep -P $process_pid)
+    echo "Process started with PID $process_pid and child PID $child_process_pid"
 }
 
 is_process_running() {
+    local process_pid=$(ps -ef | grep "exe/node" | grep -v grep | awk '{print $2}')
     ps -p $process_pid > /dev/null 2>&1
     return $?
 }
 
 kill_process() {
-    kill $process_pid
-    kill $child_process_pid
+    local process_count=$(ps -ef | grep "exe/node" | grep -v grep | wc -l)
+    local process_pids=$(ps -ef | grep "exe/node" | grep -v grep | awk '{print $2}' | xargs)
+
+    if [ $process_count -gt 0 ]; then
+        echo "killing processes $process_pids"
+        kill $process_pids
+
+        local child_process_count=$(pgrep -P $process_pids | wc -l)
+        local child_process_pids=$(pgrep -P $process_pids | xargs)
+        if [ $child_process_count -gt 0 ]; then
+            echo "killing child processes $child_process_pids"
+            kill $child_process_pids
+        else
+            echo "no child processes running"
+        fi
+    else
+        echo "no processes running"
+    fi
 }
+
+kill_process
 
 start_process
 


### PR DESCRIPTION
## why

the current state of the `node/poor_mans_cd.sh` relies on global variables to track both main process id and any child process id using the method below

```sh
start_process() {
    GOEXPERIMENT=arenas go run ./... &
    process_pid=$!
    child_process_pid=$(pgrep -P $process_pid) # this is always empty
}
```

the problem is child_process_id is always empty I assume due to race condition where child processes start after the `child_process_id` variable is initialized. This leads to the following error message upon a new update being issued and picked up by the script

`kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]`

Hence any child processes continue running, which leads to the client to loop between panicing and restarting.

## what

- [x] changes the script to use local variables instead global
- [x] always grabs the latest values for both pids and child pids
- [x] the 2 changes above transforms `kill_process` to be idempotent and hence can be called at the beginning of the script to fix currently affected nodes
- [x] additional logging for better visibility 


## steps used to replicate processes not being killed correctly

- `git reset --hard <some_previous_version_commit_hash>`
- modify old poor_man_cd.sh to sleep 60-120 seconds before executing the while loop (this step is needed to simulate a currently running node with an older version)
- run `./poor_man_cd.sh`
- after 60-120 seconds the while loop will pick up the latest commit hash and attempt to kill existing processes and start new ones
-  you will see the error message mentioned above for the kill command as `$child_process_id` will be empty
- running `ps -ef | grep "node" | grep -v grep` will show multiple ceremony client processes running

## steps to verify the changes 

- `git reset --hard <some_previous_version_commit_hash>`
- modify newest poor_man_cd.sh to sleep 60-120 seconds before executing the while loop (this step is needed to simulate a currently running node with an older version)
- run `./poor_man_cd.sh`
- after 60-120 seconds the while loop will pick up the latest commit hash and attempt to kill existing processes and start new ones
- running `ps -ef | grep "node" | grep -v grep` will show only 1 process only running of the client