### PR TITLE
another bug fix with poor_man_cd

### DIFF
--- a/node/poor_mans_cd.sh
+++ b/node/poor_mans_cd.sh
@@ -2,14 +2,13 @@
 
 start_process() {
     GOEXPERIMENT=arenas go run ./... &
-    local process_pid=$!
-    local child_process_pid=$(pgrep -P $process_pid)
-    echo "Process started with PID $process_pid and child PID $child_process_pid"
+    main_process_id=$!
+    local child_process_pid=$(pgrep -P $main_process_id)
+    echo "process started with PID $main_process_id and child PID $child_process_pid"
 }
 
 is_process_running() {
-    local process_pid=$(ps -ef | grep "exe/node" | grep -v grep | awk '{print $2}')
-    ps -p $process_pid > /dev/null 2>&1
+    ps -p $main_process_id > /dev/null 2>&1
     return $?
 }
 
@@ -40,7 +39,7 @@ start_process
 
 while true; do
     if ! is_process_running; then
-        echo "Process crashed or stopped. Restarting..."
+        echo "process crashed or stopped. restarting..."
         start_process
     fi
 


### PR DESCRIPTION
## Why

basically `is_process_running` gets called immediately after `start_process` and attempting to get the pid from `is_process_running` using `ps -ef` command doesn't find it I assume race condition, so this fix reverts back the `start_process` and `is_process_running` to use global variable renamed to `main_process_id`

### before

```
no processes running
Process started with PID 17658 and child PID 
Process crashed or stopped. Restarting...
Process started with PID 17666 and child PID 
```

### after

```
no processes running
process started with PID 17915 and child PID 
```