### PR TITLE
Print unconfirmed amount as well with balance flag

### DIFF
--- a/DOCKER-README.md
+++ b/DOCKER-README.md
@@ -18,7 +18,7 @@ docker compose up -d
 ```
 
 A `.config/` subfolder will be created under the current folder, this is mapped inside the container.
-Make sure you backup `config.ym` and `keys.yml`.
+Make sure you backup `config.yml` and `keys.yml`.
 
 
 ## Intereact with a running cotainer

--- a/node/main.go
+++ b/node/main.go
@@ -101,7 +101,8 @@ func main() {
 			panic(err)
 		}
 
-		fmt.Println("Confirmed balance:", balance.Owned, "QUIL")
+		fmt.Println("Owned balance:", balance.Owned, "QUIL")
+		fmt.Println("Unconfirmed balance:", balance.UnconfirmedOwned, "QUIL")
 
 		return
 	}


### PR DESCRIPTION
Currently, the console displays the balance as below:
```
Owned: 0  Unconfirmed: 0
```

With this PR, the output format for the balance flag will be aligned with the above format:
```
> go run ./... -balance
Owned balance: 0 QUIL
Unconfirmed balance: 0 QUIL
```