### PR TITLE
add sysctl related warning

### DIFF
--- a/DOCKER-README.md
+++ b/DOCKER-README.md
@@ -1,5 +1,29 @@
 # Quilibrium Docker Instructions
 
+## WARNING
+
+> [!WARNING]
+> Currently Docker cannot be used to run Quilibrium.
+
+There are extreme buffering requirements, especially during sync, and these in turn require `sysctl`
+configuration changes that unfortunately are not supported by Docker.
+
+The buffer related `sysctl` settings are `net.core.rmem_max` and `net.core.wmem_max` and they both
+should be set to `600,000,000` bytes. This value allows pre-buffering of the entire maximum payload
+for sync.
+
+To read the currently set values:
+```shell
+sysctl -n net.core.rmem_max
+sysctl -n net.core.wmem_max
+```
+
+To set new values:
+```shell
+sudo sysctl -w net.core.rmem_max=600000000
+sudo sysctl -w net.core.wmem_max=600000000
+```
+
 ## Build
 
 Build the docker image:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,9 @@ version: "3.8"
 
 name: quilibrium
 
+# See sysctl related warning in DOCKER-README.md.
+# Currently Docker cannot be used to run Quilibrium.
+
 services:
   node:
     build: ./


### PR DESCRIPTION
Currently Docker cannot be used to run Quilibrium. Adding warning and explanation.