### PR TITLE
fix: set peer info broadcasts to only self

### DIFF
--- a/node/consensus/ceremony/broadcast_messaging.go
+++ b/node/consensus/ceremony/broadcast_messaging.go
@@ -133,10 +133,6 @@ func (e *CeremonyDataClockConsensusEngine) handleCeremonyPeerListAnnounce(
 		return errors.Wrap(err, "handle ceremony peer list announce")
 	}
 
-	e.peerAnnounceMapMx.Lock()
-	e.peerAnnounceMap[string(peerID)] = announce
-	e.peerAnnounceMapMx.Unlock()
-
 	for _, p := range announce.PeerList {
 		e.peerMapMx.Lock()
 		if _, ok := e.uncooperativePeersMap[string(p.PeerId)]; ok {


### PR DESCRIPTION
- only broadcast own peer info (dht resolution of multiaddr fixed issue previously that made multiaddr sharing necessary)
- only emit stats for own peer