### PR TITLE
better buffer instructions and other minor changes

### DIFF
--- a/DOCKER-README.md
+++ b/DOCKER-README.md
@@ -61,7 +61,7 @@ A `.config/` subfolder will be created under the current folder, this is mapped 
 Make sure you backup `config.yml` and `keys.yml`.
 
 
-## Intereact with a running cotainer
+## Interact with a running container
 
 Drop into a shell inside a running container:
 ```shell
@@ -78,7 +78,7 @@ Get the Peer ID:
 docker compose exec node go run ./... -peer-id
 ```
 
-Get the token ballance:
+Get the token balance:
 ```shell
 docker compose exec node go run ./... -balance
 ```

--- a/DOCKER-README.md
+++ b/DOCKER-README.md
@@ -3,14 +3,20 @@
 ## WARNING
 
 > [!WARNING]
-> Currently Docker cannot be used to run Quilibrium.
+> The Quilibrium docker container requires host configuration changes.
 
 There are extreme buffering requirements, especially during sync, and these in turn require `sysctl`
-configuration changes that unfortunately are not supported by Docker.
+configuration changes that unfortunately are not supported by Docker. But if these changes are made on
+the host machine, then luckily containers seem to automatically have the larger buffers.
 
 The buffer related `sysctl` settings are `net.core.rmem_max` and `net.core.wmem_max` and they both
 should be set to `600,000,000` bytes. This value allows pre-buffering of the entire maximum payload
 for sync.
+
+You can tell that the buffer size is not large enough by noticing this log entry at beginning when 
+Quilibrium starts, a few lines below the large logo:
+> failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 2048 kiB, got: 416 kiB).
+> See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.
 
 To read the currently set values:
 ```shell
@@ -18,10 +24,20 @@ sysctl -n net.core.rmem_max
 sysctl -n net.core.wmem_max
 ```
 
-To set new values:
+To set new values, this is not a persistent change:
 ```shell
 sudo sysctl -w net.core.rmem_max=600000000
 sudo sysctl -w net.core.wmem_max=600000000
+```
+
+To persistently set the new values add a configuration file named `20-quilibrium.conf` to
+`/etc/sysctl.d/`. The file content should be:
+```
+# Quilibrium buffering requirements, especially during sync.
+# The value could be as low as 26214400, but everything would be slower.
+
+net.core.rmem_max = 600000000
+net.core.wmem_max = 600000000
 ```
 
 ## Build

--- a/DOCKER-README.md
+++ b/DOCKER-README.md
@@ -28,7 +28,7 @@ sudo sysctl -w net.core.wmem_max=600000000
 
 Build the docker image:
 ```shell
-docker build -t quilibrium -t quilibrium:1.2.9 .
+docker build --build-arg GIT_COMMIT=$(git log -1 --format=%h) -t quilibrium -t quilibrium:1.2.9 .
 ```
 
 Use latest version instead of `1.2.9`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM golang:1.20.14-alpine3.19
 
+ARG GIT_COMMIT=unspecified
+
 LABEL org.opencontainers.image.title="Quilibrium Network Node"
 LABEL org.opencontainers.image.description="Quilibrium is a decentralized alternative to platform as a service providers."
 LABEL org.opencontainers.image.vendor=Quilibrium
 LABEL org.opencontainers.image.url=https://quilibrium.com/
 LABEL org.opencontainers.image.documentation=https://quilibrium.com/docs
+LABEL org.opencontainers.image.revision=$GIT_COMMIT
 
 ENV GOEXPERIMENT=arenas
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       - DEFAULT_LISTEN_GRPC_MULTIADDR=/ip4/0.0.0.0/tcp/8337
       - DEFAULT_LISTEN_REST_MULTIADDR=/ip4/0.0.0.0/tcp/8338
+      - DEFAULT_STATS_MULTIADDR=/dns/stats.quilibrium.com/tcp/443
     ports:
       - '8336:8336/udp' # p2p
       - '127.0.0.1:8337:8337/tcp' # gRPC

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,13 @@ services:
     build: ./
     image: quilibrium
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 32G
+        reservations:
+          cpus: 12
+          memory: 16G
     environment:
       - DEFAULT_LISTEN_GRPC_MULTIADDR=/ip4/0.0.0.0/tcp/8337
       - DEFAULT_LISTEN_REST_MULTIADDR=/ip4/0.0.0.0/tcp/8338

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.8"
 name: quilibrium
 
 # See sysctl related warning in DOCKER-README.md.
-# Currently Docker cannot be used to run Quilibrium.
+# Host configuration changes are required.
 
 services:
   node:

--- a/node/config/config.go
+++ b/node/config/config.go
@@ -154,7 +154,7 @@ func LoadConfig(configPath string, proverKey string) (*Config, error) {
 		keyfile, err := os.OpenFile(
 			filepath.Join(configPath, "keys.yml"),
 			os.O_CREATE|os.O_RDWR,
-			fs.FileMode(0700),
+			fs.FileMode(0600),
 		)
 		if err != nil {
 			panic(err)

--- a/node/config/config.go
+++ b/node/config/config.go
@@ -142,6 +142,10 @@ func LoadConfig(configPath string, proverKey string) (*Config, error) {
 			config.ListenRestMultiaddr = os.Getenv("DEFAULT_LISTEN_REST_MULTIADDR")
 		}
 
+		if multiAddr := os.Getenv("DEFAULT_STATS_MULTIADDR"); multiAddr != "" {
+			config.Engine.StatsMultiaddr = multiAddr
+		}
+
 		fmt.Println("Saving config...")
 		if err = SaveConfig(configPath, config); err != nil {
 			panic(err)

--- a/node/main.go
+++ b/node/main.go
@@ -202,7 +202,7 @@ func clearIfTestData(configDir string, nodeConfig *config.Config) {
 		versionFile, err := os.OpenFile(
 			filepath.Join(configDir, "RELEASE_VERSION"),
 			os.O_CREATE|os.O_RDWR,
-			fs.FileMode(0700),
+			fs.FileMode(0600),
 		)
 		if err != nil {
 			panic(err)
@@ -232,7 +232,7 @@ func migrate(configDir string, nodeConfig *config.Config) {
 		migrationFile, err := os.OpenFile(
 			filepath.Join(configDir, "MIGRATIONS"),
 			os.O_CREATE|os.O_RDWR,
-			fs.FileMode(0700),
+			fs.FileMode(0600),
 		)
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
- the `sysctl` changes can be applied on the host
  - relax warnings
  - better instructions for the host
  - how to detect buffer size issues
- add git commit to image as a label
  - updated build command sample to provide git commit
- add resource requirements
  - docker compose is not enforcing them
- add default stats collection
- fix several config file permissions