### PR TITLE
Modify the wrong default volumes value to /root/.config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       retries: 3
       start_period: 1m
     volumes:
-      - ./.config:/opt/ceremonyclient/node/.config
+      - ./.config:/root/.config
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
When I deploy docker container today, I found volumes default value is not work in docker-compose.xml and node initialization likes a brand new one, so I entered the internal of container and found that node loaded a different path of config which is /opt/ceremonyclient/node/.config. Hope my information can help, thanks.