### PR TITLE
Exclude multiple config dirs from Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-.config
+.config*
 **/.idea
 **/.vscode
 github.env


### PR DESCRIPTION
I utilize two configuration directories, `.config` and `.config2`, for creating two separate Docker containers. 

Currently, when building the Docker image, the process includes copying the `.config2` directory into the image.  So, the image size is extreme due to the `store` subdirectory within `.config2`.

With this PR, we exclude all the `.config` dirs.