### PR TITLE
v1.4.6

### DIFF
--- a/node/app/db_console.go
+++ b/node/app/db_console.go
@@ -887,11 +887,11 @@ func logoVersion(width int) string {
 		out += "                          ''---..              ...---''               ##\n"
 		out += "                                 ''----------''\n"
 		out += " \n"
-		out += "                        Quilibrium Node - v1.4.5 – Sunset\n"
+		out += "                        Quilibrium Node - v1.4.6 – Sunset\n"
 		out += " \n"
 		out += "                                   DB Console\n"
 	} else {
-		out = "Quilibrium Node - v1.4.5 – Sunset - DB Console\n"
+		out = "Quilibrium Node - v1.4.6 – Sunset - DB Console\n"
 	}
 	return out
 }

--- a/node/consensus/ceremony/broadcast_messaging.go
+++ b/node/consensus/ceremony/broadcast_messaging.go
@@ -145,6 +145,10 @@ func (e *CeremonyDataClockConsensusEngine) handleCeremonyPeerListAnnounce(
 			continue
 		}
 
+		if !bytes.Equal(p.PeerId, peerID) {
+			continue
+		}
+
 		if p.PublicKey == nil || p.Signature == nil || p.Version == nil {
 			continue
 		}
@@ -188,7 +192,7 @@ func (e *CeremonyDataClockConsensusEngine) handleCeremonyPeerListAnnounce(
 					"peer provided outdated version, penalizing app score",
 					zap.Binary("peer_id", p.PeerId),
 				)
-				e.pubSub.SetPeerScore(p.PeerId, -100)
+				e.pubSub.SetPeerScore(p.PeerId, -10000)
 				continue
 			}
 		}

--- a/node/consensus/ceremony/ceremony_data_clock_consensus_engine.go
+++ b/node/consensus/ceremony/ceremony_data_clock_consensus_engine.go
@@ -306,6 +306,11 @@ func (e *CeremonyDataClockConsensusEngine) Start() <-chan error {
 				panic(err)
 			}
 
+			e.logger.Info(
+				"preparing peer announce",
+				zap.Uint64("frame_number", frame.FrameNumber),
+			)
+
 			timestamp := time.Now().UnixMilli()
 			msg := binary.BigEndian.AppendUint64([]byte{}, frame.FrameNumber)
 			msg = append(msg, consensus.GetVersion()...)

--- a/node/consensus/consensus_engine.go
+++ b/node/consensus/consensus_engine.go
@@ -59,5 +59,5 @@ func GetMinimumVersion() []byte {
 }
 
 func GetVersion() []byte {
-	return []byte{0x01, 0x04, 0x05}
+	return []byte{0x01, 0x04, 0x06}
 }

--- a/node/consensus/master/broadcast_messaging.go
+++ b/node/consensus/master/broadcast_messaging.go
@@ -183,7 +183,7 @@ func (e *MasterClockConsensusEngine) handleSelfTestReport(
 	)
 
 	if report.Cores < 3 || memory < 16000000000 {
-		e.logger.Info(
+		e.logger.Debug(
 			"peer reported invalid configuration",
 			zap.String("peer_id", base58.Encode(peerID)),
 			zap.Uint32("difficulty", report.Difficulty),
@@ -208,7 +208,7 @@ func (e *MasterClockConsensusEngine) handleSelfTestReport(
 
 	cc, err := e.pubSub.GetDirectChannel(peerID, "validation")
 	if err != nil {
-		e.logger.Error(
+		e.logger.Debug(
 			"could not connect for validation",
 			zap.String("peer_id", base58.Encode(peerID)),
 			zap.Uint32("difficulty", report.Difficulty),
@@ -245,7 +245,7 @@ func (e *MasterClockConsensusEngine) handleSelfTestReport(
 	cc.Close()
 
 	if !bytes.Equal(verification, validation.Validation) {
-		e.logger.Error(
+		e.logger.Debug(
 			"provided invalid verification",
 			zap.String("peer_id", base58.Encode(peerID)),
 			zap.Uint32("difficulty", report.Difficulty),
@@ -266,7 +266,7 @@ func (e *MasterClockConsensusEngine) handleSelfTestReport(
 	}
 
 	if end-start > 2000 {
-		e.logger.Error(
+		e.logger.Debug(
 			"slow bandwidth, scoring out",
 			zap.String("peer_id", base58.Encode(peerID)),
 			zap.Uint32("difficulty", report.Difficulty),

--- a/node/consensus/master/master_clock_consensus_engine.go
+++ b/node/consensus/master/master_clock_consensus_engine.go
@@ -40,22 +40,24 @@ type MasterClockConsensusEngine struct {
 	frameProver         crypto.FrameProver
 	lastFrameReceivedAt time.Time
 
-	frameChan        chan *protobufs.ClockFrame
-	executionEngines map[string]execution.ExecutionEngine
-	filter           []byte
-	input            []byte
-	syncingStatus    SyncStatusType
-	syncingTarget    []byte
-	engineMx         sync.Mutex
-	seenFramesMx     sync.Mutex
-	historicFramesMx sync.Mutex
-	seenFrames       []*protobufs.ClockFrame
-	historicFrames   []*protobufs.ClockFrame
-	clockStore       store.ClockStore
-	masterTimeReel   *qtime.MasterTimeReel
-	report           *protobufs.SelfTestReport
-	peerMapMx        sync.Mutex
-	peerMap          map[string]*protobufs.SelfTestReport
+	frameChan                   chan *protobufs.ClockFrame
+	executionEngines            map[string]execution.ExecutionEngine
+	filter                      []byte
+	input                       []byte
+	syncingStatus               SyncStatusType
+	syncingTarget               []byte
+	engineMx                    sync.Mutex
+	seenFramesMx                sync.Mutex
+	historicFramesMx            sync.Mutex
+	seenFrames                  []*protobufs.ClockFrame
+	historicFrames              []*protobufs.ClockFrame
+	clockStore                  store.ClockStore
+	masterTimeReel              *qtime.MasterTimeReel
+	report                      *protobufs.SelfTestReport
+	peerMapMx                   sync.Mutex
+	peerMap                     map[string]*protobufs.SelfTestReport
+	currentReceivingSyncPeers   int
+	currentReceivingSyncPeersMx sync.Mutex
 }
 
 var _ consensus.ConsensusEngine = (*MasterClockConsensusEngine)(nil)

--- a/node/execution/intrinsics/ceremony/ceremony_execution_engine.go
+++ b/node/execution/intrinsics/ceremony/ceremony_execution_engine.go
@@ -1386,7 +1386,7 @@ func (e *CeremonyExecutionEngine) VerifyExecution(
 						return errors.Wrap(err, "verify execution")
 					}
 
-					parent, err := e.clockStore.GetParentDataClockFrame(
+					parent, err := e.clockStore.GetStagedDataClockFrame(
 						append(
 							p2p.GetBloomFilter(application.CEREMONY_ADDRESS, 256, 3),
 							p2p.GetBloomFilterIndices(

--- a/node/main.go
+++ b/node/main.go
@@ -523,5 +523,5 @@ func printLogo() {
 
 func printVersion() {
 	fmt.Println(" ")
-	fmt.Println("                       Quilibrium Node - v1.4.5 – Sunset")
+	fmt.Println("                       Quilibrium Node - v1.4.6 – Sunset")
 }

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -576,7 +576,7 @@ func discoverPeers(
 				continue
 			}
 
-			logger.Info("found peer", zap.String("peer_id", peer.ID.Pretty()))
+			logger.Debug("found peer", zap.String("peer_id", peer.ID.Pretty()))
 			err := h.Connect(ctx, peer)
 			if err != nil {
 				logger.Debug(
@@ -585,7 +585,7 @@ func discoverPeers(
 					zap.Error(err),
 				)
 			} else {
-				logger.Info(
+				logger.Debug(
 					"connected to peer",
 					zap.String("peer_id", peer.ID.Pretty()),
 				)


### PR DESCRIPTION
- set the stage for future data reduction by consolidating candidate and parent indices to staged frames (1/3 of data saved)
- clear out all old candidate frames (including really old ones if the node still has them)
- do a deep seek to confirm integrity for sync preflight
- move future data index frames to just refer to parent indices, save more data (another 1/3)