### PR TITLE
Pin grpcurl

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 WORKDIR /opt/ceremonyclient/node
 
 RUN go install ./...
-RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.8.9
 
 FROM alpine:3.19
 


### PR DESCRIPTION
grpcurl is installed with no versioning, so each time the image is rebuilt potentially a new version of grpcurl (or one of its dependencies, or one of its dependencies’ dependencies) will change. If they’re compatible, great, but there’s no guarantee that is the case.