### PR TITLE
Add new bootstrap peers

### DIFF
--- a/node/config/config.go
+++ b/node/config/config.go
@@ -81,6 +81,8 @@ func LoadConfig(configPath string, proverKey string) (*Config, error) {
 		"/ip4/186.233.184.181/udp/8336/quic/p2p/QmW6QDvKuYqJYYMP5tMZSp12X3nexywK28tZNgqtqNpEDL",
 		"/dns/quil.zanshindojo.org/udp/8336/quic/p2p/QmXbbmtS5D12rEc4HWiHWr6e83SCE4jeThPP4VJpAQPvXq",
 		"/ip4/185.209.178.115/udp/8336/quic/p2p/Qmekz5obb9qCRP5CrZ4D8Tmabbr5mJf6mgBJHTaitrx7Fx",
+		"/ip4/186.233.187.185/udp/8336/quic/p2p/QmR7jT9NKL3yZ1iRjLxPJjAVNbk38HAfDtAKF5SCZmHdpK",
+		"/ip4/149.86.224.152/udp/8336/quic/p2p/QmaVaJ93mKaaqDnsYbHGEUBzEtbWhb3s4DAutt6JeJC5Wz",
 		"/ip4/144.76.104.93/udp/8336/quic/p2p/QmZejZ8DBGQ6foX9recW73GA6TqL6hCMX9ETWWW1Fb8xtx",
 		"/ip4/65.109.17.13/udp/8336/quic/p2p/Qmc35n99eojSvW3PkbfBczJoSX92WmnnKh3Fg114ok3oo4",
 		"/ip4/65.108.194.84/udp/8336/quic/p2p/QmP8C7g9ZRiWzhqN2AgFu5onS6HwHzR6Vv1TCHxAhnCSnq",


### PR DESCRIPTION
Adds two new bare metal bootstrap peers both with high end AMD cpus and 128GB ram. The first one is in the US and the second is in the EU. The first one is at Latitude and the second one is at an untested new provider.