### PR TITLE
p2p suggestions: save bootstrap file

### DIFF
--- a/node/main.go
+++ b/node/main.go
@@ -490,33 +490,7 @@ func loadBootstrapFile(configDir string, config *config.Config) *config.Config {
 
 func exportBootstrapFile(configDir string, node *app.Node) {
 	logger, _ := zap.NewProduction()
-	infos := node.GetPubSub().GetNetworkInfo()
-	topPeers := make(map[string]int)
-	for _, peer := range infos.NetworkInfo {
-		if peer.PeerScore > 0 && len(peer.Multiaddrs) > 0 && peer.Multiaddrs[0] != "" {
-			if len(topPeers) < 100 {
-				topPeers[peer.Multiaddrs[0]] = int(peer.PeerScore)
-			} else {
-				var replaceKey string = ""
-				for key, score := range topPeers {
-					if score < int(peer.PeerScore) {
-						replaceKey = key
-						break
-					}
-				}
-				if replaceKey != "" {
-					delete(topPeers, replaceKey)
-					topPeers[peer.Multiaddrs[0]] = int(peer.PeerScore)
-				}
-			}
-		}
-	}
-	peers := make([]string, 0)
-	for peer, _ := range topPeers {
-		if peer != "" {
-			peers = append(peers, peer)
-		}
-	}
+	peers := node.GetPubSub().ExportTopScoreBootstrap()
 	if len(peers) < 2 {
 		return // not worth saving and we could end up replacing a good value
 	}

--- a/node/p2p/pubsub.go
+++ b/node/p2p/pubsub.go
@@ -35,4 +35,5 @@ type PubSub interface {
 	GetPublicKey() []byte
 	GetPeerScore(peerId []byte) int64
 	SetPeerScore(peerId []byte, score int64)
+	ExportTopScoreBootstrap() []string
 }


### PR DESCRIPTION
I have some suggestions for the p2p code, so instead of just describing them I decided to open a PR to show what I mean. Feel free to adapt parts of it as/if it feels right.

* Save and restore top 100 connected peers as a bootstrap file to aid on restarts. This may later be used on the `reconnect` function to reboostrap in case of a connection loss. I often see this feature across p2p clients.

EDIT: removed other changes that were solved with peer info manager and the last qol

This PR now only adds support for a bootstrap file (should help bringing connectivity to a new node from an existing one or during reboots, but wont change anything on already good ones)