### PR TITLE
bugfix: skip compaction if missing data

### DIFF
--- a/node/app/node.go
+++ b/node/app/node.go
@@ -51,7 +51,11 @@ func newNode(
 	if err := clockStore.Compact(
 		intrinsicFilter,
 	); err != nil {
-		panic(err)
+		if errors.Is(err, store.ErrNotFound) {
+			logger.Error("Missing compaction data. Skipping for now.", zap.Error(err))
+		} else {
+			panic(err)
+		}
 	}
 	logger.Info("compaction complete")
 

--- a/node/store/clock.go
+++ b/node/store/clock.go
@@ -1262,7 +1262,7 @@ func (p *PebbleClockStore) Compact(
 		idxValue, closer, err := p.db.Get(clockDataLatestIndex(dataFilter))
 		if err != nil {
 			if errors.Is(err, pebble.ErrNotFound) {
-				return errors.Wrap(err, "compact")
+				return ErrNotFound
 			}
 
 			return errors.Wrap(err, "compact")
@@ -1276,7 +1276,7 @@ func (p *PebbleClockStore) Compact(
 			value, closer, err := p.db.Get(clockDataFrameKey(dataFilter, frameNumber))
 			if err != nil {
 				if errors.Is(err, pebble.ErrNotFound) {
-					return errors.Wrap(err, "compact")
+					return ErrNotFound
 				}
 
 				return errors.Wrap(err, "compact")


### PR DESCRIPTION
This fixes a bug where:
* new installs panics on compaction
* existing installs that delete `.config/store` panics on compaction
* possibly other cases

To reproduce either:
* new node
* remove `.config/store`

I'm not sure if it is ok to just skip, but this is how I fixed here.