### PR TITLE
simplify checks and avoid loop on collect

### DIFF
--- a/node/consensus/ceremony/consensus_frames.go
+++ b/node/consensus/ceremony/consensus_frames.go
@@ -269,18 +269,16 @@ func (e *CeremonyDataClockConsensusEngine) collect(
 
 	for {
 		peerId, maxFrame, err := e.GetMostAheadPeer(latest.FrameNumber)
-		if maxFrame-2 > latest.FrameNumber {
+		if err != nil {
+			e.logger.Info("no peers available for sync, waiting")
+			time.Sleep(5 * time.Second)
+		} else if maxFrame-2 > latest.FrameNumber {
 			e.syncingStatus = SyncStatusSynchronizing
+			latest, err = e.sync(latest, maxFrame, peerId)
 			if err != nil {
-				e.logger.Info("no peers available for sync, waiting")
-				time.Sleep(5 * time.Second)
+				time.Sleep(30 * time.Second)
 			} else {
-				latest, err = e.sync(latest, maxFrame, peerId)
-				if err != nil {
-					time.Sleep(30 * time.Second)
-				} else {
-					break
-				}
+				break
 			}
 		} else {
 			break

--- a/node/consensus/ceremony/consensus_frames.go
+++ b/node/consensus/ceremony/consensus_frames.go
@@ -269,12 +269,12 @@ func (e *CeremonyDataClockConsensusEngine) collect(
 
 	for {
 		peerId, maxFrame, err := e.GetMostAheadPeer(latest.FrameNumber)
-		if maxFrame > latest.FrameNumber {
+		if maxFrame-2 > latest.FrameNumber {
 			e.syncingStatus = SyncStatusSynchronizing
 			if err != nil {
 				e.logger.Info("no peers available for sync, waiting")
 				time.Sleep(5 * time.Second)
-			} else if maxFrame-2 > latest.FrameNumber {
+			} else {
 				latest, err = e.sync(latest, maxFrame, peerId)
 				if err != nil {
 					time.Sleep(30 * time.Second)

--- a/node/consensus/ceremony/consensus_frames.go
+++ b/node/consensus/ceremony/consensus_frames.go
@@ -167,7 +167,7 @@ func (e *CeremonyDataClockConsensusEngine) GetMostAheadPeer(
 			zap.Binary("version", v.version),
 		)
 		_, ok := e.uncooperativePeersMap[string(v.peerId)]
-		if v.maxFrame > max &&
+		if v.maxFrame >= max &&
 			v.timestamp > config.GetMinimumVersionCutoff().UnixMilli() &&
 			bytes.Compare(v.version, config.GetMinimumVersion()) >= 0 && !ok {
 			manifest := e.peerInfoManager.GetPeerInfo(v.peerId)


### PR DESCRIPTION
If the max frame from the best peer found is latest+1 it will loop for a bit. That is the second else for the inner if that is missing. This simplifies the logic to always break or sleep.