### PR TITLE
Master sync: parallelism, fix off by one, ignore far frames, separate bandwidth test in another thread and log progress

### DIFF
--- a/node/consensus/master/consensus_frames.go
+++ b/node/consensus/master/consensus_frames.go
@@ -44,7 +44,7 @@ func (e *MasterClockConsensusEngine) GetMostAheadPeers() (
 	max := frame.FrameNumber + 10
 
 	var peers [][]byte = [][]byte{}
-	peerMap := e.peerInfoManager.GetPeerMap()
+	peerMap := e.peerInfoManager.GetPeersBySpeed()
 	for peerId, v := range peerMap {
 		if v.MasterHeadFrame > max {
 			peers = append(peers, []byte(peerId))

--- a/node/consensus/master/master_clock_consensus_engine.go
+++ b/node/consensus/master/master_clock_consensus_engine.go
@@ -164,6 +164,14 @@ func (e *MasterClockConsensusEngine) Start() <-chan error {
 	for i := 0; i < runtime.NumCPU(); i++ {
 		go func() {
 			for newFrame := range e.frameValidationCh {
+				head, err := e.masterTimeReel.Head()
+				if err != nil {
+					panic(err)
+				}
+				if head.FrameNumber > newFrame.FrameNumber || newFrame.FrameNumber-head.FrameNumber > 1000 {
+					e.logger.Debug("Ignore frame", zap.Uint64("number", newFrame.FrameNumber))
+					continue
+				}
 				if err := e.frameProver.VerifyMasterClockFrame(newFrame); err != nil {
 					e.logger.Error("could not verify clock frame", zap.Error(err))
 					continue

--- a/node/consensus/master/master_clock_consensus_engine.go
+++ b/node/consensus/master/master_clock_consensus_engine.go
@@ -170,6 +170,12 @@ func (e *MasterClockConsensusEngine) Start() <-chan error {
 				}
 
 				e.masterTimeReel.Insert(newFrame, false)
+			}
+		}
+	}()
+	go func() {
+		for {
+			select {
 			case peerId := <-e.bandwidthTestCh:
 				e.performBandwidthTest(peerId)
 			}

--- a/node/consensus/time/master_time_reel.go
+++ b/node/consensus/time/master_time_reel.go
@@ -295,7 +295,7 @@ func (m *MasterTimeReel) processPending() {
 			break
 		}
 
-		delete(m.pending, m.head.FrameNumber+1)
+		delete(m.pending, m.head.FrameNumber)
 	}
 	deletes := []uint64{}
 	for number := range m.pending {

--- a/node/consensus/time/master_time_reel.go
+++ b/node/consensus/time/master_time_reel.go
@@ -233,7 +233,6 @@ func (m *MasterTimeReel) runLoop() {
 						frame,
 					)
 				}
-				m.processPending()
 			} else {
 				m.logger.Debug(
 					"new frame has same or lower frame number",
@@ -242,6 +241,7 @@ func (m *MasterTimeReel) runLoop() {
 				)
 				continue
 			}
+			m.processPending()
 		case <-m.done:
 			return
 		}

--- a/node/consensus/time/master_time_reel.go
+++ b/node/consensus/time/master_time_reel.go
@@ -233,6 +233,7 @@ func (m *MasterTimeReel) runLoop() {
 						frame,
 					)
 				}
+				m.processPending()
 			} else {
 				m.logger.Debug(
 					"new frame has same or lower frame number",
@@ -241,7 +242,6 @@ func (m *MasterTimeReel) runLoop() {
 				)
 				continue
 			}
-			m.processPending()
 		case <-m.done:
 			return
 		}
@@ -253,6 +253,9 @@ func (m *MasterTimeReel) processPending() {
 		ok = m.pending[m.head.FrameNumber+1] {
 
 		for _, frame := range pending {
+			m.logger.Debug(
+				"process pending",
+				zap.Uint64("number", frame.FrameNumber))
 			frame := frame
 			parent := new(big.Int).SetBytes(frame.ParentSelector)
 			selector, err := m.head.GetSelector()

--- a/node/consensus/time/master_time_reel.go
+++ b/node/consensus/time/master_time_reel.go
@@ -180,8 +180,8 @@ func (m *MasterTimeReel) runLoop() {
 		select {
 		case frame := <-m.frames:
 			if m.head.FrameNumber < frame.FrameNumber {
-				m.logger.Debug(
-					"new frame has higher number",
+				m.logger.Info(
+					"new master frame received",
 					zap.Uint32("new_frame_number", uint32(frame.FrameNumber)),
 					zap.Uint32("frame_number", uint32(m.head.FrameNumber)),
 				)

--- a/node/p2p/peer_info_manager.go
+++ b/node/p2p/peer_info_manager.go
@@ -13,7 +13,7 @@ type PeerInfoManager interface {
 	AddPeerInfo(manifest *PeerManifest)
 	GetPeerInfo(peerId []byte) *PeerManifest
 	GetPeerMap() map[string]*PeerManifest
-	GetPeersBySpeed() [][]byte
+	GetPeersBySpeed() map[string]*PeerManifest
 }
 
 type Capability struct {
@@ -111,11 +111,11 @@ func (m *InMemoryPeerInfoManager) GetPeerMap() map[string]*PeerManifest {
 	return data
 }
 
-func (m *InMemoryPeerInfoManager) GetPeersBySpeed() [][]byte {
-	result := [][]byte{}
+func (m *InMemoryPeerInfoManager) GetPeersBySpeed() map[string]*PeerManifest {
+	result := make(map[string]*PeerManifest)
 	m.peerInfoMx.RLock()
 	for _, info := range m.fastestPeers {
-		result = append(result, info.PeerId)
+		result[string(info.PeerId)] = info
 	}
 	m.peerInfoMx.RUnlock()
 	return result


### PR DESCRIPTION
Master sync happens silently for new nodes, so I was confused thinking it was stuck. This PR makes it log master frame events to info so we can see it happening.

Also, I realized bandwidth tests can arrive in waves, sometimes with dead/slow peers, stalling the master sync validation for a while. I separated a thread for it, although it still feels like it could use more CPU for new nodes.

This is a new part of the code I'm still understanding, so sorry if I got confused. Those are mostly suggestions, feel free to adapt or close.