### PR TITLE
Fixing print typo and adding peer score

### DIFF
--- a/node/main.go
+++ b/node/main.go
@@ -551,9 +551,8 @@ func printNodeInfo(cfg *config.Config) {
 	}
 
 	fmt.Println("Version: " + config.FormatVersion(nodeInfo.Version))
-
-	fmt.Println("Max Fame: " + strconv.FormatUint(nodeInfo.GetMaxFrame(), 10))
-
+	fmt.Println("Max Frame: " + strconv.FormatUint(nodeInfo.GetMaxFrame(), 10))
+	fmt.Println("Peer Score: " + strconv.FormatUint(nodeInfo.GetPeerScore(), 10))
 	printBalance(cfg)
 }
 


### PR DESCRIPTION
Watching `-node-info` is a clean way to track the progress. I have fixed a small typo and added peer score to the command:
```
Every 2.0s: docker exec -it quilibrium-node1-1 node -node-info

Peer ID: <peer_id>
Version: 1.4.13
Max Frame: 119622
Peer Score: 0
Owned balance: 0 QUIL
Unconfirmed balance: 0 QUIL
```