### PR TITLE
v1.4.14

### DIFF
--- a/node/config/version.go
+++ b/node/config/version.go
@@ -6,15 +6,15 @@ import (
 )
 
 func GetMinimumVersionCutoff() time.Time {
-	return time.Date(2024, time.March, 27, 8, 30, 0, 0, time.UTC)
+	return time.Date(2024, time.April, 4, 6, 20, 0, 0, time.UTC)
 }
 
 func GetMinimumVersion() []byte {
-	return []byte{0x01, 0x04, 0x0D}
+	return []byte{0x01, 0x04, 0x0E}
 }
 
 func GetVersion() []byte {
-	return []byte{0x01, 0x04, 0x0D}
+	return []byte{0x01, 0x04, 0x0E}
 }
 
 func GetVersionString() string {

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -160,44 +160,11 @@ func NewBlossomSub(
 	}
 
 	blossomOpts := []blossomsub.Option{}
-	if isBootstrapPeer {
-		blossomOpts = append(blossomOpts,
-			blossomsub.WithPeerExchange(true),
-		)
-	}
-
 	if tracer != nil {
 		blossomOpts = append(blossomOpts, blossomsub.WithEventTracer(tracer))
 	}
-	blossomOpts = append(blossomOpts, blossomsub.WithPeerScore(
-		&blossomsub.PeerScoreParams{
-			SkipAtomicValidation:        false,
-			BitmaskScoreCap:             0,
-			IPColocationFactorWeight:    0,
-			IPColocationFactorThreshold: 6,
-			BehaviourPenaltyWeight:      0,
-			BehaviourPenaltyThreshold:   100,
-			BehaviourPenaltyDecay:       .5,
-			DecayInterval:               10 * time.Second,
-			DecayToZero:                 .1,
-			RetainScore:                 5 * time.Minute,
-			AppSpecificScore: func(p peer.ID) float64 {
-				return float64(bs.GetPeerScore([]byte(p)))
-			},
-			AppSpecificWeight: 10.0,
-		},
-		&blossomsub.PeerScoreThresholds{
-			SkipAtomicValidation:        false,
-			GossipThreshold:             -2000,
-			PublishThreshold:            -5000,
-			GraylistThreshold:           -10000,
-			AcceptPXThreshold:           100,
-			OpportunisticGraftThreshold: 2,
-		}))
 
-	params := mergeDefaults(p2pConfig)
-	rt := blossomsub.NewBlossomSubRouter(h, params)
-	ps, err := blossomsub.NewBlossomSubWithRouter(ctx, h, rt, blossomOpts...)
+	ps, err := blossomsub.NewFloodSub(ctx, h, blossomOpts...)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Switch to floodsub for now, gossip noise storms are overwhelmingly a net negative. This temporarily disables peer scoring's effect, but should be a non-issue.