### PR TITLE
allows pinning version in poor_mans_cd.sh

### DIFF
--- a/node/poor_mans_cd.sh
+++ b/node/poor_mans_cd.sh
@@ -35,6 +35,12 @@ kill_process() {
 
 kill_process
 
+if [ $PINNED_VERSION != "" ]; then
+    echo "⚠️ pinned version detected, won't check or apply for future updates"
+    git pull
+    git reset --hard $PINNED_VERSION
+fi
+
 start_process
 
 while true; do
@@ -43,17 +49,19 @@ while true; do
         start_process
     fi
 
-    git fetch
+    if [ $PINNED_VERSION == "" ]; then
+        git fetch
 
-    local_head=$(git rev-parse HEAD)
-    remote_head=$(git rev-parse @{u})
+        local_head=$(git rev-parse HEAD)
+        remote_head=$(git rev-parse @{u})
 
-    if [ "$local_head" != "$remote_head" ]; then
-        kill_process
+        if [ "$local_head" != "$remote_head" ]; then
+            kill_process
 
-        git pull
+            git pull
 
-        start_process
+            start_process
+        fi
     fi
 
     sleep 60

--- a/node/poor_mans_cd.sh
+++ b/node/poor_mans_cd.sh
@@ -64,5 +64,5 @@ while true; do
         fi
     fi
 
-    sleep 60
+    sleep 300
 done


### PR DESCRIPTION
## what

currently when running`poor_mans_cd.sh`, there is not a convenient way to rollback a version while continuing to use the safety benefits that comes with the script

this diff adds a new env var `PINNED_VERSION` that when present uses `git reset` to rollback to a specific hash and doesn't check for future updates

if the env var isn't set, script operates as usual