### PR TITLE
Cutting peer connection error noise

### DIFF
--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -365,7 +365,7 @@ func initDHT(
 			}
 
 			if err := h.Connect(ctx, *peerinfo); err != nil {
-				logger.Info("error while connecting to dht peer", zap.Error(err))
+				logger.Debug("error while connecting to dht peer", zap.Error(err))
 			} else {
 				logger.Info(
 					"connected to peer",


### PR DESCRIPTION
I applied this change for myself, and I thought creating PR would reduce the concern for the other folks as there were many questions in our chats.

This is nothing functional, but just cutting the noise which is created by peer connection attempts. My logs are very clean after the change:
```
{"level":"info","ts":1712676614.4955556,"caller":"ceremony/consensus_frames.go:260","msg":"collecting vdf proofs"}
{"level":"info","ts":1712676614.495596,"caller":"ceremony/consensus_frames.go:151","msg":"checking peer list","peers":1482,"uncooperative_peers":12,"current_head_frame":171093}
{"level":"info","ts":1712676614.4961195,"caller":"ceremony/consensus_frames.go:304","msg":"returning leader frame","frame_number":171093}
{"level":"info","ts":1712676615.3291714,"caller":"master/master_clock_consensus_engine.go:215","msg":"peers in store","peer_store_count":344,"network_peer_count":209}
{"level":"info","ts":1712676625.3296359,"caller":"master/master_clock_consensus_engine.go:215","msg":"peers in store","peer_store_count":344,"network_peer_count":203}
{"level":"info","ts":1712676625.9440033,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"QmRLbzFmr88aQNuWit1ygymMWTgnHgaSHwCWf3R2k2E7Vb"}
{"level":"info","ts":1712676626.206909,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"QmNpPDEAMFuEThTgVmfZQkmKRu45eq3wQMVfrjzndr7CZH"}
{"level":"info","ts":1712676626.4809113,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"QmTWGB52h4cBi2dERMBUmf4jbtAbA735EJ7WtrPckAokkJ"}
{"level":"info","ts":1712676626.7550275,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"QmQg9Qt5EXuqfYNGswihDoXWyACGHLZNMp8TdD9pdjXoTx"}
{"level":"info","ts":1712676632.0785398,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"QmaDc5zn5n6hLDQt4iys3LPeAjFQ5eJDCSz4mq2jHU14Pp"}
{"level":"info","ts":1712676632.352287,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"QmbP5JCdNux9kGwUffZC86jSuNy2jLCLVqh7YGVRyQcisd"}
{"level":"info","ts":1712676632.6247463,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"QmQwYYQrLviizuxgj7VgeLuohgqhxg4ziv97WWDq2b4PHu"}
{"level":"info","ts":1712676632.8985999,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"QmSQ41h76xZQciGtTVZrahh4PQtrMcRRa4sSMgoGQxqqUe"}
{"level":"info","ts":1712676633.157564,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"QmaHDV8jaZyczzXf7kX76owQVjo3my1CgK84xauyvMkeER"}
{"level":"info","ts":1712676633.449619,"caller":"p2p/blossomsub.go:370","msg":"connected to peer","peer_id":"Qmcg2WPeSJkxKNxLU1CXAfVA7WpSTXBBdHUqJzpoBgMBJ3"}
{"level":"info","ts":1712676634.4967084,"caller":"ceremony/consensus_frames.go:260","msg":"collecting vdf proofs"}
```