### PR TITLE
Improve cross-mint config related errors

### DIFF
--- a/client/cmd/crossMint.go
+++ b/client/cmd/crossMint.go
@@ -41,7 +41,7 @@ var crossMintCmd = &cobra.Command{
 
 		config, err := config.LoadConfig(configDirectory, "")
 		if err != nil {
-			panic(errors.Wrap(err, "invalid config directory: "+configDirectory))
+			panic(errors.Wrap(err, "invalid config directory: " + configDirectory))
 			os.Exit(1)
 		}
 

--- a/client/cmd/crossMint.go
+++ b/client/cmd/crossMint.go
@@ -42,7 +42,6 @@ var crossMintCmd = &cobra.Command{
 		config, err := config.LoadConfig(configDirectory, "")
 		if err != nil {
 			panic(errors.Wrap(err, "invalid config directory: " + configDirectory))
-			os.Exit(1)
 		}
 
 		rawPeerKey, err := hex.DecodeString(config.P2P.PeerPrivKey)

--- a/client/cmd/crossMint.go
+++ b/client/cmd/crossMint.go
@@ -29,19 +29,19 @@ var crossMintCmd = &cobra.Command{
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) != 1 {
-			fmt.Printf("missing payload")
+			fmt.Printf("missing payload\n")
 			os.Exit(1)
 		}
 
 		_, err := os.Stat(configDirectory)
 		if os.IsNotExist(err) {
-			fmt.Printf("config directory doesn't exist: %s", configDirectory)
+			fmt.Printf("config directory '%s' doesn't exist, you can override the config directory with the --config flag\n", configDirectory)
 			os.Exit(1)
 		}
 
 		config, err := config.LoadConfig(configDirectory, "")
 		if err != nil {
-			fmt.Printf("invalid config directory: %s", configDirectory)
+			panic(errors.Wrap(err, "invalid config directory: "+configDirectory))
 			os.Exit(1)
 		}
 


### PR DESCRIPTION
Improve `cross-mint` config related errors:

1. Let the user know about the config path override option if the config directory is not found
2. Report the error in detail for better support if the config directory exists (e.g. `config.yml` is malformed)