### PR TITLE
shift default config directory of qclient under current folder

### DIFF
--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -25,7 +25,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(
 		&configDirectory,
 		"config",
-		"../node/.config/",
-		"config directory (default is ../node/.config/)",
+		".config/",
+		"config directory (default is .config/)",
 	)
 }


### PR DESCRIPTION
`qclient` by default expects the config folder under `../node/.config/` which is not working when the binary is run from PATH.

The workaround is to run the command like:
```shell
qclient <sub-command> --config .config <args>
```

This PR fixes the config loading to default it to `.config/` (that is `.config/` under current folder).

Related issue: https://github.com/QuilibriumNetwork/ceremonyclient/issues/175