### PR TITLE
Don't run self-test in DHT-only mode

### DIFF
--- a/client/cmd/crossMint.go
+++ b/client/cmd/crossMint.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 
 	"github.com/cloudflare/circl/sign/ed448"
+	"github.com/iden3/go-iden3-crypto/poseidon"
 	libP2pCrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/mr-tron/base58"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"go.uber.org/zap"
@@ -23,25 +25,75 @@ var crossMintCmd = &cobra.Command{
 	Short: "Signs a payload from the Quilibrium bridge to mint tokens on Ethereum L1 and prints the result to stdout",
 	Long: `Signs a payload from the Quilibrium bridge to mint tokens on Ethereum L1 and prints the result to stdout":
 	
-	cross-mint <Payload>
+	cross-mint <Payload> [<Voucher File Path>]
 	
 	Payload – the hex-encoded payload from the Quilibrium bridge with optional 0x-prefix, must be specified
+	Voucher File Path – (optional) the path to a voucher private key, from the initial KZG ceremony
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		if len(args) != 1 {
-			fmt.Printf("missing payload")
+		if len(args) < 1 {
+			fmt.Println("missing payload")
 			os.Exit(1)
+		}
+
+		if len(args) > 2 {
+			fmt.Println("invalid command")
+			os.Exit(1)
+		}
+
+		if len(args) == 2 {
+			rawVoucherHex, err := os.ReadFile(args[1])
+			if err != nil {
+				fmt.Printf("invalid file: %s\n", args[1])
+				os.Exit(1)
+			}
+
+			rawVoucherKey, err := hex.DecodeString(string(rawVoucherHex))
+			if err != nil {
+				panic(errors.Wrap(err, "cross mint"))
+			}
+
+			ed448Key := ed448.PrivateKey(rawVoucherKey)
+
+			result, err := CrossMint(&CrossMintArgs{
+				Payload:    args[0],
+				PeerKey:    ed448Key,
+				ProvingKey: ed448Key,
+			})
+			if err != nil {
+				panic(errors.Wrap(err, "error cross minting"))
+			}
+
+			pubkeyBytes := ed448Key.Public().(ed448.PublicKey)
+
+			addr, err := poseidon.HashBytes(pubkeyBytes)
+			if err != nil {
+				panic(errors.Wrap(err, "error cross minting"))
+			}
+
+			addrBytes := addr.Bytes()
+			addrBytes = append(make([]byte, 32-len(addrBytes)), addrBytes...)
+
+			// Print the result
+			fmt.Println("Voucher ID: " + base58.Encode(addrBytes))
+
+			jsonResult, err := json.Marshal(result)
+			if err != nil {
+				panic(errors.Wrap(err, "error marshaling result to json"))
+			}
+			fmt.Println(string(jsonResult))
+			os.Exit(0)
 		}
 
 		_, err := os.Stat(configDirectory)
 		if os.IsNotExist(err) {
-			fmt.Printf("config directory doesn't exist: %s", configDirectory)
+			fmt.Printf("config directory doesn't exist: %s\n", configDirectory)
 			os.Exit(1)
 		}
 
 		config, err := config.LoadConfig(configDirectory, "")
 		if err != nil {
-			fmt.Printf("invalid config directory: %s", configDirectory)
+			fmt.Printf("invalid config directory: %s\n", configDirectory)
 			os.Exit(1)
 		}
 

--- a/client/go.mod
+++ b/client/go.mod
@@ -8,7 +8,11 @@ replace source.quilibrium.com/quilibrium/monorepo/node => ../node
 
 replace source.quilibrium.com/quilibrium/monorepo/nekryptology => ../nekryptology
 
-require github.com/stretchr/testify v1.8.4
+require (
+	github.com/iden3/go-iden3-crypto v0.0.15
+	github.com/mr-tron/base58 v1.2.0
+	github.com/stretchr/testify v1.8.4
+)
 
 require (
 	filippo.io/edwards25519 v1.0.0-rc.1 // indirect

--- a/client/go.sum
+++ b/client/go.sum
@@ -33,6 +33,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/iden3/go-iden3-crypto v0.0.15 h1:4MJYlrot1l31Fzlo2sF56u7EVFeHHJkxGXXZCtESgK4=
+github.com/iden3/go-iden3-crypto v0.0.15/go.mod h1:dLpM4vEPJ3nDHzhWFXDjzkn1qHoBeOT/3UEhXsEsP3E=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/ipfs/go-cid v0.4.1 h1:A/T3qGvxi4kpKWWcPC/PgbvDA2bjVLO7n4UeVwnbs/s=
@@ -50,6 +52,7 @@ github.com/libp2p/go-buffer-pool v0.1.0 h1:oK4mSFcQz7cTQIfqbe4MIj9gLW+mnanjyFtc6
 github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dzMM=
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mr-tron/base58 v1.2.0 h1:T/HDJBh4ZCPbU39/+c3rRvE0uKBQlU27+QI8LJ4t64o=
+github.com/mr-tron/base58 v1.2.0/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=
 github.com/multiformats/go-base32 v0.1.0 h1:pVx9xoSPqEIQG8o+UbAe7DNi51oej1NtK+aGkbLYxPE=
 github.com/multiformats/go-base36 v0.2.0 h1:lFsAbNOGeKtuKozrtBsAkSVhv1p9D0/qedU9rQyccr0=
 github.com/multiformats/go-multiaddr v0.11.0 h1:XqGyJ8ufbCE0HmTDwx2kPdsrQ36AGPZNZX6s6xfJH10=

--- a/node/main.go
+++ b/node/main.go
@@ -185,13 +185,6 @@ func main() {
 		return
 	}
 
-	if !*dhtOnly {
-		fmt.Println("Loading ceremony state and starting node...")
-		kzg.Init()
-	}
-
-	report := RunSelfTestIfNeeded(*configDirectory, nodeConfig)
-
 	if *dhtOnly {
 		dht, err := app.NewDHTNode(nodeConfig)
 		if err != nil {
@@ -206,6 +199,11 @@ func main() {
 		dht.Stop()
 		return
 	}
+
+	fmt.Println("Loading ceremony state and starting node...")
+	kzg.Init()
+
+	report := RunSelfTestIfNeeded(*configDirectory, nodeConfig)
 
 	var node *app.Node
 	if *debug {


### PR DESCRIPTION
## Problem

The node tries to create a self-test when ran with the `-dht-only` flag, but it doesn't load the KZG ceremony data in DHT-only mode which leads to a crash.

## Solution

Don't run self-test when the `-dht-only` flag is set.

## Testing

I tested by starting a node locally in default mode with and without existing self-test and with the `-dht-only` flag.