### PR TITLE
Remove bootstrap peer

### DIFF
--- a/node/config/config.go
+++ b/node/config/config.go
@@ -63,7 +63,6 @@ var BootstrapPeers = []string{
 	"/ip4/87.98.167.207/udp/8336/quic/p2p/QmafiAXLu1JWktyfzDtD67i78GRBYCfQ4doTfq7pp7wfQ1",
 	"/ip4/216.244.76.122/udp/8336/quic/p2p/QmUSbMytVBUYiiGE266aZHrHrP17vLx5UJFd7o74HkDoaV",
 	"/ip4/216.244.79.194/udp/8336/quic/p2p/QmQn3bWk5aqaNSv9dwPjBg4qdeGBGNEB72tvuhgEc64Ki5",
-	"/ip4/5.199.168.233/udp/8336/quic/p2p/QmeV1f11qjPTPaPspkJfdUb7p8kJ3fgsCqqozBtaW4nGFh",
 	// purged peers (keep your node online to return to this list)
 	// "/ip4/204.186.74.47/udp/8317/quic/p2p/Qmd233pLUDvcDW3ama27usfbG1HxKNh1V9dmWVW1SXp1pd",
 	// "/ip4/186.233.184.181/udp/8336/quic/p2p/QmW6QDvKuYqJYYMP5tMZSp12X3nexywK28tZNgqtqNpEDL",


### PR DESCRIPTION
This node will no longer run after 26/5, so want to remove it to avoid issues for others.