### PR TITLE
Update main.go to fix Q logo in cli

### DIFF
--- a/node/main.go
+++ b/node/main.go
@@ -192,7 +192,7 @@ func main() {
 				os.Exit(1)
 			}
 
-			fmt.Printf("Signature check passed")
+			fmt.Println("Signature check passed")
 		}
 	}
 


### PR DESCRIPTION
Q logo is not appearing correctly on the terminal while running node. Printing a new line character after "Signature check passed" will fix it