### PR TITLE
Fix docker-compose volume mapping for .config folder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       retries: 3
       start_period: 1m
     volumes:
-      - ./.config:/root/.config
+      - ./node/.config:/root/.config
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
Change volume mapping so .config folder is created inside node folder and not on root folder.