### PR TITLE
fix arm64 architecture error

### DIFF
--- a/node/release_autorun.sh
+++ b/node/release_autorun.sh
@@ -3,7 +3,7 @@
 start_process() {
     version=$(cat config/version.go | grep -A 1 "func GetVersion() \[\]byte {" | grep -Eo '0x[0-9a-fA-F]+' | xargs printf "%d.%d.%d")
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        if [[ $arch == arm* ]]; then
+        if [[ $(uname -m) == "aarch64"* ]]; then
             ./node-$version-linux-arm64 &
             main_process_id=$!
         else


### PR DESCRIPTION
There is no `$arch` variable to identify the architecture, `uname -m` should be used to determine the architecture.