### PR TITLE
Feat Accelerate Startup by Connecting Peers Concurrently and Initializing KZG When Needed

### DIFF
--- a/node/main.go
+++ b/node/main.go
@@ -323,7 +323,6 @@ func main() {
 	}
 
 	fmt.Println("Loading ceremony state and starting node...")
-	kzg.Init()
 
 	report := RunSelfTestIfNeeded(*configDirectory, nodeConfig)
 
@@ -428,6 +427,7 @@ func RunSelfTestIfNeeded(
 		logger.Info("no self-test report found, generating")
 	}
 
+	kzg.Init()
 	report := &protobufs.SelfTestReport{}
 	difficulty := nodeConfig.Engine.Difficulty
 	if difficulty == 0 {


### PR DESCRIPTION
This pull request aims to accelerate the startup process of our program by addressing two key areas:

1. **Connecting Peers Concurrently:**
   The process of establishing peer connections is I/O intensive. The `h.Connect` function is thread-safe and can be executed concurrently. By connecting peers concurrently, especially when multiple bootstrap nodes are unreachable, we can significantly reduce the startup time that would otherwise be spent waiting for timeouts.

2. **Initializing KZG When Needed:**
   I found that KZG is utilized in only two scenarios:
   - When the `SELF_TEST` file is not present, it is used in the process of generating `SELF_TEST`.
   - In the ceremony engine, which has not been used since version 1.4.18.

In most startup scenarios, the code path that generates `SELF_TEST` is not executed. Therefore, the initialization of KZG can be moved to just before the generation of `SELF_TEST` to reduce the startup time.

By implementing these changes, we can achieve a more efficient startup process, minimizing unnecessary delays and improving overall performance.