### PR TITLE
v1.4.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +155,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -168,7 +185,9 @@ dependencies = [
 name = "bls48581"
 version = "0.1.0"
 dependencies = [
+ "criterion 0.4.0",
  "hex 0.4.3",
+ "rand",
  "serde_json",
  "uniffi",
 ]
@@ -270,6 +289,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
+version = "3.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+dependencies = [
+ "bitflags",
+ "clap_lex 0.2.4",
+ "indexmap",
+ "textwrap",
+]
+
+[[package]]
+name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
@@ -286,7 +317,7 @@ checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
 dependencies = [
  "anstream",
  "anstyle",
- "clap_lex",
+ "clap_lex 0.7.0",
  "strsim",
 ]
 
@@ -304,6 +335,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
@@ -312,7 +352,7 @@ checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 name = "classgroup"
 version = "0.1.0"
 dependencies = [
- "criterion",
+ "criterion 0.5.1",
  "libc",
  "num-traits",
 ]
@@ -325,6 +365,32 @@ checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "criterion"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c76e09c1aae2bc52b3d2f29e13c6572553b30c4aa1b8a49fd70de6412654cb"
+dependencies = [
+ "anes",
+ "atty",
+ "cast",
+ "ciborium",
+ "clap 3.2.25",
+ "criterion-plot",
+ "itertools",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
@@ -332,7 +398,7 @@ dependencies = [
  "anes",
  "cast",
  "ciborium",
- "clap",
+ "clap 4.5.4",
  "criterion-plot",
  "is-terminal",
  "itertools",
@@ -430,6 +496,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,6 +534,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,6 +550,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -487,12 +579,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
  "windows-sys",
 ]
@@ -526,6 +628,12 @@ checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -611,6 +719,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2355d85b9a3786f481747ced0e0ff2ba35213a1f9bd406ed906554d7af805a1"
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +765,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,6 +786,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -834,6 +984,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+
+[[package]]
 name = "thiserror"
 version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,7 +1057,7 @@ checksum = "21345172d31092fd48c47fd56c53d4ae9e41c4b1f559fb8c38c1ab1685fd919f"
 dependencies = [
  "anyhow",
  "camino",
- "clap",
+ "clap 4.5.4",
  "uniffi_bindgen",
  "uniffi_build",
  "uniffi_core",
@@ -918,7 +1074,7 @@ dependencies = [
  "askama",
  "camino",
  "cargo_metadata",
- "clap",
+ "clap 4.5.4",
  "fs-err",
  "glob",
  "goblin",
@@ -1037,7 +1193,7 @@ version = "0.1.0"
 dependencies = [
  "bit-vec",
  "classgroup",
- "criterion",
+ "criterion 0.5.1",
  "hex 0.3.2",
  "num-traits",
  "sha2",
@@ -1059,6 +1215,12 @@ dependencies = [
  "same-file",
  "winapi-util",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1134,6 +1296,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1319,12 @@ checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/crates/bls48581/Cargo.toml
+++ b/crates/bls48581/Cargo.toml
@@ -12,5 +12,13 @@ hex = "0.4.3"
 serde_json = "1.0.117"
 uniffi = {  version= "0.25", features = ["cli"]}
 
+[dev-dependencies]
+criterion = { version = "0.4", features = ["html_reports"] }
+rand = "0.8.5"
+
 [build-dependencies]
 uniffi = { version = "0.25", features = [ "build" ] }
+
+[[bench]]
+name = "bench_bls"
+harness = false

--- a/crates/bls48581/benches/bench_bls.rs
+++ b/crates/bls48581/benches/bench_bls.rs
@@ -1,0 +1,20 @@
+use rand::Rng;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+fn criterion_benchmark(c: &mut Criterion) {
+  bls48581::init();
+  let mut bytes = vec![0u8; 65536];
+  rand::thread_rng().fill(&mut bytes[..]);
+  
+  let mut group = c.benchmark_group("commit");
+  group.sample_size(10);
+  group.bench_function("commit 16", |b| b.iter(|| black_box(bls48581::commit_raw(&bytes, 16))));
+  group.bench_function("commit 128", |b| b.iter(|| black_box(bls48581::commit_raw(&bytes, 128))));
+  group.bench_function("commit 256", |b| b.iter(|| black_box(bls48581::commit_raw(&bytes, 256))));
+  group.bench_function("commit 1024", |b| b.iter(|| black_box(bls48581::commit_raw(&bytes, 1024))));
+  group.bench_function("commit 65536", |b| b.iter(|| black_box(bls48581::commit_raw(&bytes, 65536))));
+  group.finish();
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/node/app/db_console.go
+++ b/node/app/db_console.go
@@ -725,11 +725,11 @@ func logoVersion(width int) string {
 		out += "                          ''---..              ...---''               ##\n"
 		out += "                                 ''----------''\n"
 		out += " \n"
-		out += "                       Quilibrium Node - v" + config.GetVersionString() + " – Solstice\n"
+		out += "                       Quilibrium Node - v" + config.GetVersionString() + " – Centauri\n"
 		out += " \n"
 		out += "                                   DB Console\n"
 	} else {
-		out = "Quilibrium Node - v" + config.GetVersionString() + " – Solstice - DB Console\n"
+		out = "Quilibrium Node - v" + config.GetVersionString() + " – Centauri - DB Console\n"
 	}
 	return out
 }

--- a/node/config/p2p.go
+++ b/node/config/p2p.go
@@ -38,4 +38,6 @@ type P2PConfig struct {
 	TraceLogFile              string        `yaml:"traceLogFile"`
 	MinPeers                  int           `yaml:"minPeers"`
 	Network                   uint8         `yaml:"network"`
+	LowWatermarkConnections   uint          `yaml:"lowWatermarkConnections"`
+	HighWatermarkConnections  uint          `yaml:"highWatermarkConnections"`
 }

--- a/node/config/version.go
+++ b/node/config/version.go
@@ -14,7 +14,7 @@ func GetMinimumVersion() []byte {
 }
 
 func GetVersion() []byte {
-	return []byte{0x01, 0x04, 0x14}
+	return []byte{0x01, 0x04, 0x15}
 }
 
 func GetVersionString() string {
@@ -36,5 +36,5 @@ func FormatVersion(version []byte) string {
 }
 
 func GetPatchNumber() byte {
-	return 0x01
+	return 0x00
 }

--- a/node/crypto/channel/feldman_test.go
+++ b/node/crypto/channel/feldman_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"source.quilibrium.com/quilibrium/monorepo/nekryptology/pkg/core/curves"
-	"source.quilibrium.com/quilibrium/monorepo/node/crypto"
+	crypto "source.quilibrium.com/quilibrium/monorepo/node/crypto/channel"
 )
 
 func TestFeldman(t *testing.T) {

--- a/node/main.go
+++ b/node/main.go
@@ -933,5 +933,5 @@ func printVersion() {
 		patchString = fmt.Sprintf("-p%d", patch)
 	}
 	fmt.Println(" ")
-	fmt.Println("                      Quilibrium Node - v" + config.GetVersionString() + patchString + " – Solstice")
+	fmt.Println("                      Quilibrium Node - v" + config.GetVersionString() + patchString + " – Centauri")
 }

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -64,7 +64,7 @@ var BITMASK_ALL = []byte{
 // While we iterate through these next phases, we're going to aggressively
 // enforce keeping updated. This will be achieved through announce strings
 // that will vary with each update
-var ANNOUNCE_PREFIX = "quilibrium-1.4.20-solstice-"
+var ANNOUNCE_PREFIX = "quilibrium-1.4.21-centauri-"
 
 func getPeerID(p2pConfig *config.P2PConfig) peer.ID {
 	peerPrivKey, err := hex.DecodeString(p2pConfig.PeerPrivKey)


### PR DESCRIPTION
The final update prior to the v2.0 release.

Extreme performance drilldown on the BLS implementation, needed for fast confirmation times. Also adds some parameterization to connection management for bootstrap systems wanting to expand out the defaults.

## Before

Prior (golang) commits:
|poly_size|time|
|-|-|
|16|43ms|
|128|336ms|
|1024|2808ms|
|65536|165.651s|

Proofs:
|poly_size|time|
|-|-|
|16|43ms|
|128|359ms|
|1024|2.826s|
|65536|178.355s|

Prior (rust) commits in ms:
|poly_size|time|
|-|-|
|16|12ms|
|128|93ms|
|1024|736ms|
|65536|47.521s|

Proofs:
|poly_size|time|
|-|-|
|16|16ms|
|128|133ms|
|1024|1.102s|
|65536|73.836s|

## After
Commits:
|poly_size|time|
|-|-|
|16|166**µ**s|
|128|166**µ**s|
|1024|200ms|
|65536|9.592s|

Proofs:
|poly_size|time|
|-|-|
|16|164**µ**s|
|128|166**µ**s|
|1024|331ms|
|65536|17.402s|

The final amount of juice to squeeze on this would be via parallelization of the DFT –  should be able to bring down the time down on the 65536 case by a strong degree.