### PR TITLE
Streamline cluster configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,90 @@ Testing the [`vdf`](./vdf) and [`node`](./node) packages requires linking the
 [native VDF](./crates/vdf). The `test.sh` scripts in the respective directories
 help with this.
 
+## Setting Up a Local Testnet
+
+To set up and run a local testnet for development and testing purposes, you can use the `run_testnet.sh` script provided in the repository. This script automates the process of setting up multiple nodes on your local machine, including installing necessary prerequisites.
+
+To use the script:
+
+1. Run the script from the repository root:
+
+   ```
+   ./run_testnet.sh
+   ```
+
+2. The script will check for and install prerequisites (Rust, Go, GMP, cpulimit) if they're not already present.
+
+3. It will then display recommended settings based on your system resources and ask if you want to use them. If not, you can manually define the parameters.
+
+You can also customize the testnet setup using command-line options:
+
+- `--recompile-libs`: Force recompilation of libraries
+- `--reinstall-deps`: Reinstall dependencies
+- `--redo-config`: Recreate node configurations
+- `--node-count <number>`: Set the number of nodes to run
+- `--cores-per-node <number>`: Set the number of cores per node (minimum 4)
+- `--cpu-limit <percentage>`: Set CPU usage limit per node
+- `--timeout <seconds>`: Set a timeout for the testnet run
+- `--dry-run`: Perform a dry run without actually starting the nodes
+
+For example:
+
+```
+./run_testnet.sh --node-count 6 --cores-per-node 4 --cpu-limit 50 --timeout 3600
+```
+
+This local testnet setup is useful for testing network interactions, consensus mechanisms, and other features that require multiple nodes.
+
+Note: The script will attempt to install prerequisites automatically, but some systems may require manual intervention or additional setup steps depending on the specific environment.
+
+#### Validating a working testnet
+
+You can run: 
+```bash
+grpcurl -plaintext localhost:8337 quilibrium.node.node.pb.NodeService.GetNodeInfo
+
+# Output should be:
+# {
+#   "peerId": "Qm...", // the peer id printed out in the console when running the testnet startup script
+#   "maxFrame": "0", // varies depending on how long it has been running until you ran the command
+#   "version": "AQQVAQ==" // will vary depending on version of the binarys
+# }
+```
+### Manually Installing Dependencies
+
+Based on the `run_testnet.sh` script, here's a list of prerequisites that may need to be installed manually, depending on your system:
+
+#### Linux Dependencies
+
+| Dependency | Version | Install Command |
+|------------|---------|-----------------|
+| Rust | Latest | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` |
+| Go | 1.22.4 | `wget https://golang.org/dl/go1.22.4.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf go1.22.4.linux-amd64.tar.gz` |
+| GMP | Latest | `sudo apt-get install libgmp-dev` |
+| curl | Latest | `sudo apt-get install curl` |
+| build-essential | Latest | `sudo apt-get install build-essential` |
+| wget | Latest | `sudo apt-get install wget` |
+| uniffi-bindgen-go | v0.2.1+v0.25.0 | `cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.1+v0.25.0` |
+| grpcurl | Latest | `go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest` |
+| cpulimit | Latest | `sudo apt-get install cpulimit` |
+
+#### macOS Dependencies
+
+| Dependency | Version | Install Command |
+|------------|---------|-----------------|
+| Rust | Latest | `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh` |
+| Homebrew | Latest | `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"` |
+| Go | 1.22.4 | `brew install go@1.22.4` |
+| GMP | Latest | `brew install gmp` |
+| curl | Latest | `brew install curl` |
+| wget | Latest | `brew install wget` |
+| uniffi-bindgen-go | v0.2.1+v0.25.0 | `cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.1+v0.25.0` |
+| grpcurl | Latest | `go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest` |
+| cpulimit | Latest | `brew install cpulimit` |
+
+Note: The script attempts to install these prerequisites automatically. However, depending on your system configuration, you might need to install some of these manually if the automatic installation fails. In such cases, you would need to use your system's package manager (apt, brew, etc.) to install the missing components before running the script again.
+
 ## Pull Requests
 
 Contributions are welcome – a new network is rife with opportunities. We are
@@ -36,4 +120,3 @@ task build_node_amd64_linux
 ```
 
 The output binaries will be in `node/build`.
-

--- a/README.md
+++ b/README.md
@@ -13,7 +13,29 @@ Running production nodes from source is no longer recommended given build comple
 
 Builds are now a hybrid of Rust and Go, so you will need both go 1.22 and latest Rust + Cargo.
 
-### VDF
+### Prerequisites
+
+Before running from source, ensure you have the necessary prerequisites installed. We provide an `install_dependencies.sh` script that will automatically install the required dependencies for Linux and macOS systems. To use it:
+
+1. Make the script executable:
+   ```
+   chmod +x install_dependencies.sh
+   ```
+
+2. Run the script:
+   ```
+   ./install_dependencies.sh
+   ```
+
+This script will install:
+- Rust (latest version)
+- Go (version 1.22.4)
+- GMP (GNU Multiple Precision Arithmetic Library)
+- Other necessary dependencies specific to your operating system
+
+For manual installation or for other operating systems, please refer to the [CONTRIBUTING.md](CONTRIBUTING.md#manually-installing-dependencies) file for detailed instructions.
+
+### Compiling VDF and BLS48581 Libraries
 
 The VDF implementation is now in Rust, and requires GMP to build. On Mac, you can install GMP with brew (`brew install gmp`). On Linux, you will need to find the appropriate package for your distro.
 
@@ -23,16 +45,67 @@ Install the go plugin for uniffi-rs:
 
 Be sure to follow the PATH export given by the installer.
 
+#### VDF
 Build the Rust VDF implementation by navigating to the vdf folder, and run `./generate.sh`.
 
-### Node
+#### BLS48581
+Similarly, for the BLS48581 implementation, navigate to the bls48581 folder and run `./generate.sh`.
 
-Because of the Rust interop, be sure you follow the above steps for the VDF before proceeding to this. Navigate to the node folder, and run (making sure to update the path for the repo):
+### Compiling the Node binary
 
-    CGO_LDFLAGS="-L/path/to/ceremonyclient/target/release -lvdf -ldl -lm" \
-        CGO_ENABLED=1 \
-        GOEXPERIMENT=arenas \
-        go run ./... --signature-check=false
+Because of the Rust interop, be sure you follow the above steps for the VDF and BLS48581 libraries before proceeding to this. 
+
+Navigate to the `node` folder, and run:
+    GOEXPERIMENT=arenas CGO_ENABLED=1 go build \
+      -ldflags "-linkmode 'external' -extldflags '-L$(dirname $(dirname $(realpath $0)))/target/release -lvdf -lbls48581 -ldl -lm'" \
+      -o node main.go
+
+#### Running Your Compiled Node Version
+
+For local development, specific use-cases, or running custom versions, you can run the node binary without signature checks. This is primarily useful for testing, debugging, and experimenting with modifications to the node software.
+
+To run the node binary without signature checks (it will fail otherwise):
+
+1. Navigate to the `node` directory:
+
+   ```
+   cd node
+   ```
+
+2. Run the node with the `--signature-check=false` flag:
+
+   ```
+   ./node --signature-check=false
+   ```
+
+   This flag disables signature checks and sets up the node for local development.
+
+3. Optionally, you can specify a custom config file:
+
+   ```
+   ./node --signature-check=false --config path/to/your/config.yml
+   ```
+   ```
+
+Note: Running without signature checks should generally never be used in production, i.e. on the mainnet. It bypasses important security measures and should only be employed for specific, well-defined use-cases where the risks are fully understood and mitigated. Do not use this option simply because it's available; always consider the security implications carefully.
+
+### Running a Local Testnet
+
+For development and testing purposes, you can set up a local testnet using the `run_testnet.sh` script. This script automates the process of setting up and running multiple test nodes on your local machine.
+
+To use the script:
+
+1. Run the script from the repository root:
+
+   ```
+   ./run_testnet.sh
+   ```
+
+2. The script will guide you through the setup process, including recommending the number of nodes and CPU limits based on your system resources.
+
+Once you have run this once, it will give you a command that you can use to run the nodes once you have completed the setup in order to avoid having to interact with the prompts again.
+
+You can customize the testnet setup using command-line options. For more detailed information on setting up a local testnet, including available options and manual dependency installation, please refer to the [Contributing Guide](CONTRIBUTING.md#setting-up-a-local-testnet).
 
 ## gRPC/REST Support
 
@@ -60,7 +133,7 @@ Note that this feature requires that [gRPC support](#grpcrest-support) is enable
 This section contains community-built clients, applications, guides, etc <br /><br />
 <b>Disclaimer</b>: Because some of these may contain external links, do note that these are unofficial – every dependency added imparts risk, so if another project's github account were compromised, for example, it could lead people down a dangerous or costly path. Proceed with caution as always and refer to reliable members of the community for verification of links before clicking or connecting your wallets
 
-### 1. The Q Guide - Beginners’ Guide
+### 1. The Q Guide - Beginners' Guide
 
 - A detailed beginners' guide for how to setup a Quilibrium Node, created by [@demipoet](https://www.github.com/demipoet) - [link](https://quilibrium.guide/)<br/>
 

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+
+set -e
+
+# Function to install dependencies
+install_dependencies() {
+    # Detect OS and architecture
+    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+    ARCH=$(uname -m)
+
+    # Install dependencies
+    if [[ "$OS" == "linux" ]]; then
+        sudo apt-get update -qq
+        sudo apt-get install -y -qq curl build-essential libgmp-dev wget cpulimit
+    elif [[ "$OS" == "darwin" ]]; then
+        if ! command -v brew &> /dev/null; then
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" > /dev/null
+        fi
+        brew install -q curl gmp wget cpulimit
+    else
+        echo "Unsupported operating system: $OS"
+        exit 1
+    fi
+}
+
+# Function to install Rust and Go
+install_rust_and_go() {
+    # Check if Rust is installed
+    if ! command -v rustc &> /dev/null; then
+        echo "Rust not found. Installing Rust..."
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        source $HOME/.cargo/env
+        echo 'export PATH=$PATH:$HOME/.cargo/env' >> $HOME/.bashrc
+        echo 'export PATH=$PATH:$HOME/.cargo/env' >> $HOME/.zshrc
+    else
+        echo "Rust is already installed."
+    fi
+
+    # Install uniffi-bindgen-go 
+    if ! command -v uniffi-bindgen-go &> /dev/null; then
+        echo "uniffi-bindgen-go not found. Installing..."
+        cargo install uniffi-bindgen-go --git https://github.com/NordSecurity/uniffi-bindgen-go --tag v0.2.1+v0.25.0
+    else
+        echo "uniffi-bindgen-go is already installed."
+    fi
+
+    # Check if Go is installed
+    if ! command -v go &> /dev/null; then
+        echo "Go not found. Installing Go..."
+        GO_VERSION="1.22.4"
+        if [[ "$OS" == "linux" ]]; then
+            if [[ "$ARCH" == "x86_64" ]]; then
+                GO_ARCH="amd64"
+            elif [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" ]]; then
+                GO_ARCH="arm64"
+            else
+                echo "Unsupported architecture: $ARCH"
+                exit 1
+            fi
+            wget "https://go.dev/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
+            sudo tar -C /usr/local -xzf "go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
+            rm "go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
+        elif [[ "$OS" == "darwin" ]]; then
+            if [[ "$ARCH" == "x86_64" ]]; then
+                GO_ARCH="amd64"
+            elif [[ "$ARCH" == "arm64" ]]; then
+                GO_ARCH="arm64"
+            else
+                echo "Unsupported architecture: $ARCH"
+                exit 1
+            fi
+            wget "https://go.dev/dl/go${GO_VERSION}.darwin-${GO_ARCH}.tar.gz"
+            sudo tar -C /usr/local -xzf "go${GO_VERSION}.darwin-${GO_ARCH}.tar.gz"
+            rm "go${GO_VERSION}.darwin-${GO_ARCH}.tar.gz"
+        fi
+
+        echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.bashrc
+        echo 'export PATH=$PATH:/usr/local/go/bin' >> $HOME/.zshrc
+        source $HOME/.bashrc
+
+        # Install grpcurl for RPC testing
+        go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
+    else
+        echo "Go is already installed."
+    fi
+}
+
+# Run the installation functions
+install_dependencies
+install_rust_and_go
+
+echo "All dependencies have been installed successfully."

--- a/node/config/engine.go
+++ b/node/config/engine.go
@@ -18,8 +18,22 @@ type EngineConfig struct {
 	DataWorkerMemoryLimit    int64  `yaml:"dataWorkerMemoryLimit"`
 	// Alternative configuration path to manually specify data workers by multiaddr
 	DataWorkerMultiaddrs []string `yaml:"dataWorkerMultiaddrs"`
+	Cluster              Cluster  `yaml:"cluster"`
 
 	// Values used only for testing – do not override these in production, your
 	// node will get kicked out
 	Difficulty uint32 `yaml:"difficulty"`
+}
+
+type Cluster struct {
+	Enabled        bool             `yaml:"enabled"`
+	MachineConfigs []ClusterMachine `yaml:"machineConfigs"`
+}
+
+type ClusterMachine struct {
+	IpAddress                string `yaml:"ipAddress"`
+	Priority                 uint8  `yaml:"priority"`
+	DataWorkerProcessesCount uint16 `yaml:"dataWorkerProcessesCount"`
+	DataWorkerBaseListenPort uint16 `yaml:"dataWorkerBaseListenPort"`
+	DataWorkerMemoryLimit    int64  `yaml:"dataWorkerMemoryLimit"`
 }

--- a/node/config/engine.go
+++ b/node/config/engine.go
@@ -32,8 +32,6 @@ type Cluster struct {
 
 type ClusterMachine struct {
 	IpAddress                string `yaml:"ipAddress"`
-	Priority                 uint8  `yaml:"priority"`
 	DataWorkerProcessesCount uint16 `yaml:"dataWorkerProcessesCount"`
 	DataWorkerBaseListenPort uint16 `yaml:"dataWorkerBaseListenPort"`
-	DataWorkerMemoryLimit    int64  `yaml:"dataWorkerMemoryLimit"`
 }

--- a/node/consensus/master/master_clock_consensus_engine.go
+++ b/node/consensus/master/master_clock_consensus_engine.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"net"
 	"sync"
 	"time"
 
@@ -248,7 +249,16 @@ func (e *MasterClockConsensusEngine) Start() <-chan error {
 		}
 
 		var clients []protobufs.DataIPCServiceClient
-		if len(e.engineConfig.DataWorkerMultiaddrs) != 0 {
+		if e.engineConfig.Cluster.Enabled {
+			if len(e.engineConfig.Cluster.MachineConfigs) == 0 {
+				panic("Invalid user configuration in config, the cluster machine config must have at least one entry")
+			}
+
+			clients, err = e.createParallelDataClientsFromClusterList()
+			if err != nil {
+				panic(err)
+			}
+		} else if len(e.engineConfig.DataWorkerMultiaddrs) != 0 {
 			clients, err = e.createParallelDataClientsFromList()
 			if err != nil {
 				panic(err)
@@ -598,6 +608,67 @@ func (e *MasterClockConsensusEngine) createParallelDataClientsFromListAndIndex(
 		zap.Uint32("client", index),
 	)
 	return client, nil
+}
+
+func (
+	e *MasterClockConsensusEngine,
+) createParallelDataClientsFromClusterList() (
+	[]protobufs.DataIPCServiceClient,
+	error,
+) {
+	parallelism := 0
+	for _, machineConfig := range e.engineConfig.Cluster.MachineConfigs {
+		parallelism += int(machineConfig.DataWorkerProcessesCount)
+	}
+
+	e.logger.Info(
+		"connecting to data worker processes",
+		zap.Int("parallelism", parallelism),
+	)
+
+	clients := make([]protobufs.DataIPCServiceClient, parallelism)
+
+	for _, machineConfig := range e.engineConfig.Cluster.MachineConfigs {
+		ipAddress := machineConfig.IpAddress
+		if net.ParseIP(ipAddress) == nil {
+			panic("invalid ip address: " + ipAddress)
+		}
+		for i := 0; i < int(machineConfig.DataWorkerProcessesCount); i++ {
+			port := int(machineConfig.DataWorkerBaseListenPort) + i
+			ma, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ipAddress, port))
+			if err != nil {
+				panic(err)
+			}
+
+			_, addr, err := mn.DialArgs(ma)
+			if err != nil {
+				panic(err)
+			}
+
+			conn, err := grpc.Dial(
+				addr,
+				grpc.WithTransportCredentials(
+					insecure.NewCredentials(),
+				),
+				grpc.WithDefaultCallOptions(
+					grpc.MaxCallSendMsgSize(10*1024*1024),
+					grpc.MaxCallRecvMsgSize(10*1024*1024),
+				),
+			)
+			if err != nil {
+				panic(err)
+			}
+
+			clients[i] = protobufs.NewDataIPCServiceClient(conn)
+		}
+
+	}
+
+	e.logger.Info(
+		"connected to data worker processes",
+		zap.Int("parallelism", parallelism),
+	)
+	return clients, nil
 }
 
 func (

--- a/node/consensus/master/master_clock_consensus_engine.go
+++ b/node/consensus/master/master_clock_consensus_engine.go
@@ -618,6 +618,12 @@ func (
 ) {
 	parallelism := 0
 	for _, machineConfig := range e.engineConfig.Cluster.MachineConfigs {
+		// There needs to be at least one data worker process per machine, if defined at all
+		if machineConfig.DataWorkerProcessesCount == 0 {
+			panic("DataWorkerProcessesCount for " + machineConfig.IpAddress + " is not set or is zero." +
+				" This must be set to a non-zero value.")
+		}
+
 		parallelism += int(machineConfig.DataWorkerProcessesCount)
 	}
 
@@ -631,8 +637,9 @@ func (
 	for _, machineConfig := range e.engineConfig.Cluster.MachineConfigs {
 		ipAddress := machineConfig.IpAddress
 		if net.ParseIP(ipAddress) == nil {
-			panic("invalid ip address: " + ipAddress)
+			panic("Invalid IP address: " + ipAddress)
 		}
+
 		for i := 0; i < int(machineConfig.DataWorkerProcessesCount); i++ {
 			port := int(machineConfig.DataWorkerBaseListenPort) + i
 			ma, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ipAddress, port))

--- a/run_testnet.sh
+++ b/run_testnet.sh
@@ -1,0 +1,436 @@
+#!/bin/bash
+
+set -e
+
+PROJECT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Function to compile libraries
+compile_libs() {
+    # Install Rust packages
+    echo "Starting VDF generation..."
+    cd $PROJECT_DIR/vdf
+    ./generate.sh > /dev/null 2>&1
+    echo "VDF generation completed."
+
+    echo "Starting BLS48581 generation..."
+    cd $PROJECT_DIR/bls48581
+    ./generate.sh > /dev/null 2>&1
+    echo "BLS48581 generation completed."
+
+    # Build node binary
+    echo "Building node binary..."
+    cd $PROJECT_DIR/node
+    # The file path needs to be absolute to avoid issues with go build-- i.e. the variable needs to be expanded out when the command is run
+    GOEXPERIMENT=arenas CGO_ENABLED=1 go build -ldflags "-linkmode 'external' -extldflags '-L$(echo $PROJECT_DIR)/target/release -lvdf -lbls48581 -ldl -lm'" -o node main.go
+    echo "Node binary build completed."
+}
+
+get_peer_id() {
+    local config_suffix=$1
+    local output=$($PROJECT_DIR/node/node --signature-check=false --network=1 --config=.config$config_suffix --peer-id)
+    echo "$output" | grep "Peer ID:" | awk '{print $3}'
+}
+
+# New variables for node count, cores per node, and CPU limit
+NODE_COUNT=2
+CORES_PER_NODE=4
+CPU_LIMIT_PERCENT=25
+
+# Function to parse command line arguments
+parse_arguments() {
+    while [[ $# -gt 0 ]]; do
+        key="$1"
+        case $key in
+            --recompile-libs)
+            RECOMPILE_LIBS=true
+            shift
+            ;;
+            --reinstall-deps)
+            REINSTALL_DEPS=true
+            shift
+            ;;
+            --redo-config)
+            REDO_CONFIG=true
+            shift
+            ;;
+            --node-count)
+            NODE_COUNT="$2"
+            NODE_COUNT_SET=true
+            shift 2
+            ;;
+            --cores-per-node)
+            CORES_PER_NODE="$2"
+            if [ "$CORES_PER_NODE" -lt 4 ]; then
+                echo "Error: Minimum cores per node is 4. Setting to 4."
+                CORES_PER_NODE=4
+            fi
+            CORES_PER_NODE_SET=true
+            shift 2
+            ;;
+            --cpu-limit)
+            CPU_LIMIT_PERCENT="$2"
+            CPU_LIMIT_SET=true
+            shift 2
+            ;;
+            --timeout)
+            TIMEOUT="$2"
+            shift 2
+            ;;
+            --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+            *)
+            echo "Unknown option: $key"
+            exit 1
+            ;;
+        esac
+    done
+}
+
+# Function to get current CPU utilization
+get_cpu_utilization() {
+    local cpu_idle=$(top -bn1 | grep "Cpu(s)" | sed "s/.*, *\([0-9.]*\)%* id.*/\1/" | awk '{print $1}')
+    echo "$(awk "BEGIN {print 100 - $cpu_idle}")"
+}
+
+# Function to recommend node count and CPU limit
+recommend_resources() {
+    local total_cores=$(nproc)
+    local total_memory=$(free -g | awk '/^Mem:/{print $2}')
+    local current_cpu_usage=$(get_cpu_utilization)
+    local available_cpu=$(awk "BEGIN {print 100 - $current_cpu_usage}")
+    
+    local recommended_nodes=$(( total_cores / 4 ))
+    local recommended_cores_per_node=4  # Default to 4 cores per node (minimum required)
+    local recommended_cpu_limit=$(awk "BEGIN {print int($available_cpu / $recommended_nodes)}")
+    
+    # Ensure we have at least 1 node and don't exceed 100% CPU
+    recommended_nodes=$(( recommended_nodes > 0 ? recommended_nodes : 1 ))
+    recommended_cpu_limit=$(( recommended_cpu_limit > 0 ? (recommended_cpu_limit < 100 ? recommended_cpu_limit : 100) : 10 ))
+    
+    echo "System resources:"
+    echo "  Total CPU cores: $total_cores"
+    echo "  Available memory: ${total_memory}GB"
+    echo "  Current CPU usage: ${current_cpu_usage}%"
+    echo "  Available CPU: ${available_cpu}%"
+    echo ""
+    echo "Recommended configuration:"
+    echo "  Number of nodes: $recommended_nodes"
+    echo "  Cores per node: $recommended_cores_per_node"
+    echo "  CPU limit per node: ${recommended_cpu_limit}%"
+    echo ""
+    
+    # Ask user if they want to use the recommended values
+    read -p "Do you want to use these recommended values? (y/n) [y]: " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        # Prompt user for values
+        read -p "Enter the number of nodes [$recommended_nodes]: " user_nodes
+        NODE_COUNT=${user_nodes:-$recommended_nodes}
+        
+        while true; do
+            read -p "Enter the number of cores per node (minimum 4) [$recommended_cores_per_node]: " user_cores
+            CORES_PER_NODE=${user_cores:-$recommended_cores_per_node}
+            if [ "$CORES_PER_NODE" -ge 4 ]; then
+                break
+            else
+                echo "Error: Minimum cores per node is 4. Please enter a value of 4 or higher."
+            fi
+        done
+        
+        read -p "Enter the CPU limit per node (%) [$recommended_cpu_limit]: " user_cpu_limit
+        CPU_LIMIT_PERCENT=${user_cpu_limit:-$recommended_cpu_limit}
+    else
+        NODE_COUNT=$recommended_nodes
+        CORES_PER_NODE=$recommended_cores_per_node
+        CPU_LIMIT_PERCENT=$recommended_cpu_limit
+    fi
+    
+    echo "Configuration set:"
+    echo "  Number of nodes: $NODE_COUNT"
+    echo "  Cores per node: $CORES_PER_NODE"
+    echo "  CPU limit per node: ${CPU_LIMIT_PERCENT}%"
+    echo ""
+    echo "To start with these values next time, use the following command:"
+    echo "$0 --node-count $NODE_COUNT --cores-per-node $CORES_PER_NODE --cpu-limit $CPU_LIMIT_PERCENT"
+}
+
+# Function to check available resources
+check_resources() {
+    local total_cores=$(nproc)
+    local total_memory=$(free -g | awk '/^Mem:/{print $2}')
+    local required_cpu=$((NODE_COUNT * CPU_LIMIT_PERCENT))
+    local required_memory=$((NODE_COUNT * 2)) # Assuming each node needs 2GB of RAM
+
+    if [ $required_cpu -gt 100 ]; then
+        echo "Error: Total CPU usage exceeds 100%. Required: $required_cpu%, Available: 100%"
+        exit 1
+    fi
+
+    if [ $required_memory -gt $total_memory ]; then
+        echo "Error: Not enough memory available. Required: ${required_memory}GB, Available: ${total_memory}GB"
+        exit 1
+    fi
+
+    echo "Resource check passed. Available cores: $total_cores, Available memory: ${total_memory}GB"
+}
+
+# Function to setup configuration
+setup_config() {
+    cd $PROJECT_DIR/node
+    # Delete any existing config directories
+    rm -rf .config*
+    peer_ids=()
+    
+    # Step 1: Generate configs and collect peer IDs
+    for i in $(seq 1 $NODE_COUNT); do
+        if [[ $i -eq 1 ]]; then
+            CONFIG_SUFFIX=""
+        else
+            CONFIG_SUFFIX="$i"
+        fi
+        
+        # Get the peer ID for the config
+        peer_ids[$i]=$(get_peer_id "$CONFIG_SUFFIX")
+        echo "Peer ID for node $i: ${peer_ids[$i]}"
+
+        # Remove existing bootstrap peers
+        sed -i '/bootstrapPeers:/,/^  listenMultiaddr:/!b;/^  listenMultiaddr:/!d;/^  listenMultiaddr:/s/^/  bootstrapPeers:\n/' $PROJECT_DIR/node/.config$CONFIG_SUFFIX/config.yml
+
+        # Update listen address
+        sed -i "s|^  listenMultiaddr: /ip4/0.0.0.0/udp/8336/quic-v1|  listenMultiaddr: /ip4/127.0.0.1/tcp/833$i|" $PROJECT_DIR/node/.config$CONFIG_SUFFIX/config.yml
+        # Calculate the starting dataworker port for this node
+        START_PORT=$((40000 + (i - 1) * CORES_PER_NODE))
+        
+        # Remove the default empty array for dataWorkerMultiaddrs
+        sed -i 's/^  dataWorkerMultiaddrs: \[\]/  dataWorkerMultiaddrs:/' $PROJECT_DIR/node/.config$CONFIG_SUFFIX/config.yml
+        
+        # Add dataWorkerMultiaddrs for each worker
+        for j in $(seq 1 $((CORES_PER_NODE - 1))); do
+            sed -i '/^  dataWorkerMultiaddrs:/a\    - /ip4/127.0.0.1/tcp/'"$((START_PORT + j))" $PROJECT_DIR/node/.config$CONFIG_SUFFIX/config.yml
+        done
+    done
+
+    # Step 2: Update bootstrap peers
+    for i in $(seq 1 $NODE_COUNT); do
+        if [[ $i -eq 1 ]]; then
+            CONFIG_SUFFIX=""
+        else
+            CONFIG_SUFFIX="$i"
+        fi
+        
+        # Add all other nodes as bootstrap peers
+        for j in $(seq 1 $NODE_COUNT); do
+            if [ $i -ne $j ]; then
+                sed -i '/bootstrapPeers:/a\  - /ip4/127.0.0.1/tcp/833'"$j"'/p2p/'"${peer_ids[$j]}" $PROJECT_DIR/node/.config$CONFIG_SUFFIX/config.yml
+            fi
+        done
+
+        # Set log file for each node
+        if [[ $i -eq 1 ]]; then
+            sed -i 's|logFile:.*|logFile: "output.log"|' $PROJECT_DIR/node/.config/config.yml
+        else
+            sed -i 's|logFile:.*|logFile: "output'"$i"'.log"|' $PROJECT_DIR/node/.config$CONFIG_SUFFIX/config.yml
+        fi
+    done
+
+    # Expose REST and gRPC ports on main node to access RPC services
+    sed -i 's|listenRESTMultiaddr:.*|listenRESTMultiaddr: /ip4/127.0.0.1/tcp/8335|' $PROJECT_DIR/node/.config/config.yml
+    sed -i 's|listenGrpcMultiaddr:.*|listenGrpcMultiaddr: /ip4/127.0.0.1/tcp/8337|' $PROJECT_DIR/node/.config/config.yml
+    
+
+    echo "Configuration setup complete."
+}
+
+# ANSI color codes
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+# Function to start nodes
+start_nodes() {
+    cd $PROJECT_DIR/node
+    
+    for i in $(seq 1 $NODE_COUNT); do
+        core_index=0
+
+        if [[ $i -eq 1 ]]; then
+            CONFIG_SUFFIX=""
+        else
+            CONFIG_SUFFIX="$i"
+        fi
+
+        # Start the main process
+        echo -e "${YELLOW}Starting main process for node $i${NC}"
+        MAIN_CMD="$PROJECT_DIR/node/node --signature-check=false --network=1 --config=.config$CONFIG_SUFFIX --core=$core_index"
+        echo -e "${YELLOW}Command: $MAIN_CMD${NC}"
+        if [ "$DRY_RUN" = false ]; then
+            $MAIN_CMD 2>&1 | sed "s/^/[NODE $i] /" &
+            node_pid=$!
+            echo -e "${GREEN}Node $i started with PID $node_pid${NC}"
+            core_index=$((core_index + 1))
+        else
+            echo -e "${YELLOW}[DRY RUN] Would execute: $MAIN_CMD${NC}"
+            core_index=$((core_index + 1))
+        fi
+        
+        # Start worker processes
+        for j in $(seq 1 $((CORES_PER_NODE - 1))); do
+            echo -e "${YELLOW}Starting worker process $j for node $i${NC}"
+            WORKER_CMD="$PROJECT_DIR/node/node --signature-check=false --network=1 --config=.config$CONFIG_SUFFIX --parent-process=$node_pid --core=$core_index"
+            echo -e "${YELLOW}Command: $WORKER_CMD${NC}"
+            if [ "$DRY_RUN" = false ]; then
+                $WORKER_CMD 2>&1 | sed "s/^/[NODE $i WORKER $j] /" &
+                worker_pid=$!
+                echo -e "${GREEN}Node $i Worker $j started with PID $worker_pid${NC}"
+                core_index=$((core_index + 1))
+            else
+                echo -e "${YELLOW}[DRY RUN] Would execute: $WORKER_CMD${NC}"
+                core_index=$((core_index + 1))
+            fi
+        done
+
+        # Apply CPU limit to the entire process group
+        if [ "$DRY_RUN" = false ]; then
+            cpulimit -p $node_pid -l $CPU_LIMIT_PERCENT &
+            echo -e "${GREEN}CPU limit applied to Node $i (PID $node_pid)${NC}"
+        else
+            echo -e "${YELLOW}[DRY RUN] Would execute: cpulimit -p $node_pid -l $CPU_LIMIT_PERCENT${NC}"
+        fi
+    done
+    if [ "$DRY_RUN" = false ]; then
+        echo -e "${GREEN}Local testnet started. $NODE_COUNT nodes are running in the background, each with $CORES_PER_NODE cores (1 main + $((CORES_PER_NODE - 1)) workers) and limited to $CPU_LIMIT_PERCENT% CPU usage.${NC}"
+    else
+        echo -e "${YELLOW}Dry run completed. No nodes were started.${NC}"
+    fi
+}
+
+# Function to stop nodes
+stop_nodes() {
+    echo "Stopping all nodes..."
+    pkill -f "$PROJECT_DIR/node/node"
+    echo "All nodes stopped."
+}
+
+# Function to handle timeout
+handle_timeout() {
+    echo "Timeout reached. Stopping all nodes..."
+    cleanup
+    exit 0
+}
+
+# Function to clean up on exit
+cleanup() {
+    # Cancel timeout if it's still active
+    if [ -n "$TIMEOUT_PID" ]; then
+        kill $TIMEOUT_PID 2>/dev/null
+    fi
+    stop_nodes
+    exit
+}
+
+# Parse command line arguments
+RECOMPILE_LIBS=false
+REINSTALL_DEPS=false
+REDO_CONFIG=false
+NODE_COUNT_SET=false
+CORES_PER_NODE_SET=false
+CPU_LIMIT_SET=false
+TIMEOUT=""
+DRY_RUN=false
+parse_arguments "$@"
+
+# If no parameters are set, inform about defaults and ask for confirmation
+if [ "$NODE_COUNT_SET" = false ] && [ "$CORES_PER_NODE_SET" = false ] && [ "$CPU_LIMIT_SET" = false ]; then
+    echo "Default configuration:"
+    echo "  Number of nodes: $NODE_COUNT"
+    echo "  Cores per node: $CORES_PER_NODE"
+    echo "  CPU limit per node: ${CPU_LIMIT_PERCENT}%"
+    echo ""
+    read -p "Do you want to use these default values? (y/n) [y]: " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        recommend_resources
+    fi
+else
+    # If any parameter is set, use recommend_resources to fill in the blanks
+    if [ "$NODE_COUNT_SET" = false ] || [ "$CPU_LIMIT_SET" = false ] || [ "$CORES_PER_NODE_SET" = false ]; then
+        echo "Using default values for unspecified parameters:"
+        [ "$NODE_COUNT_SET" = false ] && echo "  Number of nodes: $NODE_COUNT"
+        [ "$CORES_PER_NODE_SET" = false ] && echo "  Cores per node: $CORES_PER_NODE"
+        [ "$CPU_LIMIT_SET" = false ] && echo "  CPU limit per node: ${CPU_LIMIT_PERCENT}%"
+        echo ""
+        read -p "Do you want to continue with these values? (y/n) [y]: " -n 1 -r
+        echo
+        if [[ $REPLY =~ ^[Nn]$ ]]; then
+            recommend_resources
+        fi
+    fi
+fi
+
+# Check available resources
+check_resources
+
+# Check if dependencies are installed or if reinstallation is requested
+if ! command -v rustc &> /dev/null || ! command -v go &> /dev/null || $REINSTALL_DEPS; then
+    echo "Installing dependencies..."
+    ./install_dependencies.sh
+else
+    echo "Dependencies already installed. Skipping installation."
+fi
+
+# Check if the node binary exists or if recompilation is requested
+if [[ ! -f "$PROJECT_DIR/node/node" ]] || $RECOMPILE_LIBS; then
+    echo "Node binary not found or recompilation requested. Compiling libraries..."
+    compile_libs
+else
+    echo "Node binary found. Skipping library compilation."
+fi
+
+# Check if config files exist, if recompilation is requested, or if redo config is requested
+config_files_exist=true
+for i in $(seq 1 $NODE_COUNT); do
+    if [[ $i -eq 1 ]]; then
+        CONFIG_SUFFIX=""
+    else
+        CONFIG_SUFFIX="$i"
+    fi
+    if [[ ! -f "$PROJECT_DIR/node/.config$CONFIG_SUFFIX/config.yml" ]]; then
+        config_files_exist=false
+        break
+    fi
+done
+
+if [[ $config_files_exist == false ]] || $REDO_CONFIG; then
+    echo "Setting up configuration..."
+    setup_config
+else
+    echo "All config files found and no redo requested. Skipping configuration setup."
+fi
+
+echo "Setup complete. You can now run the start_nodes function to start the testnet."
+
+# Set up trap to catch termination signals
+trap cleanup SIGINT SIGTERM SIGHUP
+
+# Start nodes
+start_nodes
+
+echo "Press Ctrl+C to stop all nodes..."
+
+# Set up timeout if specified
+if [ -n "$TIMEOUT" ]; then
+    echo "Testnet will automatically stop after $TIMEOUT seconds."
+    (sleep $TIMEOUT && handle_timeout) &
+    TIMEOUT_PID=$!
+fi
+
+# Set up trap to catch termination signals and cancel timeout
+trap 'cleanup; [ -n "$TIMEOUT_PID" ] && kill $TIMEOUT_PID 2>/dev/null' SIGINT SIGTERM SIGHUP
+
+# Wait indefinitely
+while true; do
+    sleep 1
+done


### PR DESCRIPTION
There are two parts to this.

# Starting control process with minimal config for clusters
The aim is that a Node Runner can add to their cluster by the following config changes:
```yml
...
engine:
  ...
  cluster:
    enabled: true
    machineConfigs:
      - ipAddress: 127.0.0.1 # required
        dataWorkerProcessesCount: 127 # required
        dataWorkerBaseListenPort: 40100 # default = 40000
    - ipAddress: 192.168.0.110
      dataWorkerProcessesCount: 128
   # ... etc.
 ```

this will tell the node's control process to create clients for addresses /ip4/<ipAddress>/tcp/<dataWorkerBaseListenPort + index>

So, the above config will create clients for: 
- 127.0.0.1:40100-40227
- 192.168.0.110:40000-40128


# Starting a data worker with no config
To start workers, a script just needs to start the data-workers:
## For 127.0.0.1 config
```bash
~/ceremonyclient/node/node-1.4.21.1-amd-linux --core 1 --core-base-listen-port 40100
```
## For 182.168.0.110
```bash
~/ceremonyclient/node/node-1.4.21.1-amd-linux --core 1 // defaults listen port to 40000
```

This could be scripted, such that:

```bash
DEFAULT_CORES=$(nproc)
## could find if there are already 'node' processes running and subtract, but for simplicities sake
DATA_WORKER_COUNT="${1:-$DEFAULT_CORES}"
BASE_LISTEN_PORT=${2:-40000}

CORE=1
while CORE <= $DATA_WORKER_COUNT; do
  ~/ceremonyclient/node/node-1.4.21.1-amd-linux --core $CORE --core-base-listen-port $BASE_LISTEN_PORT
   CORE=$CORE + 1
done
```