### PR TITLE
Fixing 'Update to go.mod needed' issue

### DIFF
--- a/Dockerfile.source
+++ b/Dockerfile.source
@@ -40,6 +40,7 @@ RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 # Build and install qclient
 WORKDIR /opt/ceremonyclient/client
 
+RUN go mod tidy
 RUN go build -o qclient ./main.go
 
 # Allows exporting single binary


### PR DESCRIPTION
Docker build from the source fails as below:
```
1.520 go: updates to go.mod needed; to update it:
1.520 	go mod tidy

Dockerfile.source:43
--------------------
  41 |     WORKDIR /opt/ceremonyclient/client
  42 |     
  43 | >>> RUN go build -o qclient ./main.go
  44 |     
  45 |     # Allows exporting single binary

```