### PR TITLE
Support pprof profiling via HTTP

### DIFF
--- a/node/main.go
+++ b/node/main.go
@@ -225,6 +225,7 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
+		defer f.Close()
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
 	}

--- a/node/main.go
+++ b/node/main.go
@@ -11,6 +11,8 @@ import (
 	"io/fs"
 	"log"
 	"math/big"
+	"net/http"
+	npprof "net/http/pprof"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -76,6 +78,11 @@ var (
 		"memprofile",
 		"",
 		"write memory profile after 20m to this file",
+	)
+	pprofServer = flag.String(
+		"pprof-server",
+		"",
+		"enable pprof server on specified address (e.g. localhost:6060)",
 	)
 	nodeInfo = flag.Bool(
 		"node-info",
@@ -228,6 +235,18 @@ func main() {
 		defer f.Close()
 		pprof.StartCPUProfile(f)
 		defer pprof.StopCPUProfile()
+	}
+
+	if *pprofServer != "" && *core == 0 {
+		go func() {
+			mux := http.NewServeMux()
+			mux.HandleFunc("/debug/pprof/", npprof.Index)
+			mux.HandleFunc("/debug/pprof/cmdline", npprof.Cmdline)
+			mux.HandleFunc("/debug/pprof/profile", npprof.Profile)
+			mux.HandleFunc("/debug/pprof/symbol", npprof.Symbol)
+			mux.HandleFunc("/debug/pprof/trace", npprof.Trace)
+			log.Fatal(http.ListenAndServe(*pprofServer, mux))
+		}()
 	}
 
 	if *balance {


### PR DESCRIPTION
This PR adds support for the [pprof HTTP endpoints](https://pkg.go.dev/net/http/pprof) in the `node` binary. This allows profiling running nodes on demand, instead of using the existing file based options.

cc @CassOnMars 