### PR TITLE
Fix peer discovery

### DIFF
--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -924,9 +924,10 @@ func discoverPeers(
 	routingDiscovery *routing.RoutingDiscovery,
 	init bool,
 ) {
-	logger.Info("initiating peer discovery")
-
 	discover := func() {
+		logger.Info("initiating peer discovery")
+		defer logger.Info("completed peer discovery")
+
 		peerChan, err := routingDiscovery.FindPeers(
 			ctx,
 			getNetworkNamespace(p2pConfig.Network),
@@ -937,11 +938,10 @@ func discoverPeers(
 		}
 
 		for peer := range peerChan {
-			peer := peer
 			if peer.ID == h.ID() ||
 				h.Network().Connectedness(peer.ID) == network.Connected ||
 				h.Network().Connectedness(peer.ID) == network.Limited {
-				return
+				continue
 			}
 
 			logger.Debug("found peer", zap.String("peer_id", peer.ID.String()))
@@ -966,8 +966,6 @@ func discoverPeers(
 	} else {
 		discover()
 	}
-
-	logger.Info("completed peer discovery")
 }
 
 func mergeDefaults(p2pConfig *config.P2PConfig) blossomsub.BlossomSubParams {

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -937,27 +937,34 @@ func discoverPeers(
 			return
 		}
 
+		wg := &sync.WaitGroup{}
+		defer wg.Wait()
 		for peer := range peerChan {
-			if peer.ID == h.ID() ||
-				h.Network().Connectedness(peer.ID) == network.Connected ||
-				h.Network().Connectedness(peer.ID) == network.Limited {
-				continue
-			}
+			peer := peer
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if peer.ID == h.ID() ||
+					h.Network().Connectedness(peer.ID) == network.Connected ||
+					h.Network().Connectedness(peer.ID) == network.Limited {
+					return
+				}
 
-			logger.Debug("found peer", zap.String("peer_id", peer.ID.String()))
-			err := h.Connect(ctx, peer)
-			if err != nil {
-				logger.Debug(
-					"error while connecting to blossomsub peer",
-					zap.String("peer_id", peer.ID.String()),
-					zap.Error(err),
-				)
-			} else {
-				logger.Debug(
-					"connected to peer",
-					zap.String("peer_id", peer.ID.String()),
-				)
-			}
+				logger.Debug("found peer", zap.String("peer_id", peer.ID.String()))
+				err := h.Connect(ctx, peer)
+				if err != nil {
+					logger.Debug(
+						"error while connecting to blossomsub peer",
+						zap.String("peer_id", peer.ID.String()),
+						zap.Error(err),
+					)
+				} else {
+					logger.Debug(
+						"connected to peer",
+						zap.String("peer_id", peer.ID.String()),
+					)
+				}
+			}()
 		}
 	}
 


### PR DESCRIPTION
This PR fixes an issue introduced by commit 7eaf8e05412086ed5f52023f7211aea487865afc where the peer lookup discovery stops early instead of skipping peers. The symptoms of this are that peers are not discovered (duh), and also over time there is a CPU and memory leak due to the background lookup processes.

It also reintroduces the parallel peer connections, but compared to the old parallel connection method, it waits for the connection attempts to end before finishing the discovery. This ensures that multiple discovery processes don't overlap (well, minus the initial one, but one time is fine).