### PR TITLE
Additional peering connection improvements

### DIFF
--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -384,7 +384,7 @@ func NewBlossomSub(
 	bs.h = h
 	bs.signKey = privKey
 
-	allowedPeerIDs := map[peer.ID]struct{}{}
+	allowedPeerIDs := make(map[peer.ID]struct{}, len(allowedPeers))
 	for _, peerInfo := range allowedPeers {
 		allowedPeerIDs[peerInfo.ID] = struct{}{}
 	}
@@ -705,9 +705,13 @@ func initDHT(
 	}
 
 	reconnect := func() {
+		wg := &sync.WaitGroup{}
+		defer wg.Wait()
 		for _, peerinfo := range bootstrappers {
 			peerinfo := peerinfo
+			wg.Add(1)
 			go func() {
+				defer wg.Done()
 				if peerinfo.ID == h.ID() ||
 					h.Network().Connectedness(peerinfo.ID) == network.Connected ||
 					h.Network().Connectedness(peerinfo.ID) == network.Limited {
@@ -729,10 +733,21 @@ func initDHT(
 
 	reconnect()
 
+	bootstrapPeerIDs := make(map[peer.ID]struct{}, len(bootstrappers))
+	for _, peerinfo := range bootstrappers {
+		bootstrapPeerIDs[peerinfo.ID] = struct{}{}
+	}
 	go func() {
 		for {
 			time.Sleep(30 * time.Second)
-			if len(h.Network().Peers()) == 0 {
+			found := false
+			for _, p := range h.Network().Peers() {
+				if _, ok := bootstrapPeerIDs[p]; ok {
+					found = true
+					break
+				}
+			}
+			if !found {
 				reconnect()
 			}
 		}

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -384,11 +384,22 @@ func NewBlossomSub(
 	bs.h = h
 	bs.signKey = privKey
 
+	allowedPeerIDs := map[peer.ID]struct{}{}
+	for _, peerInfo := range allowedPeers {
+		allowedPeerIDs[peerInfo.ID] = struct{}{}
+	}
 	go func() {
 		for {
 			time.Sleep(30 * time.Second)
 			for _, b := range bs.bitmaskMap {
-				if len(b.ListPeers()) < 4 {
+				bitmaskPeers := b.ListPeers()
+				peerCount := len(bitmaskPeers)
+				for _, p := range bitmaskPeers {
+					if _, ok := allowedPeerIDs[p]; ok {
+						peerCount--
+					}
+				}
+				if peerCount < 4 {
 					discoverPeers(p2pConfig, bs.ctx, logger, bs.h, routingDiscovery, false)
 					break
 				}


### PR DESCRIPTION
This PR proposes two changes to the peering mechanism:
1. When considering if a bitmask needs more peers, do not take into account the bootstrap and the direct nodes. This achieves two things - it reduces the dependence on the bootstrap for non bootstrap operations (as the bootstraps are overloaded), and it ensures that a direct peers mesh is not accidentally solipsistic - well connected within itself, but not with the rest of the network.
2. Ensure that at least one bootstrap peer is always connected, in order to allow peer lookups, should they be required. Additional concurrency guards have been added - `reconnect` won't finish until it has either connected or at least attempted to connect to the bootstraps, so there won't be a goroutine leak.