### PR TITLE
Fix merge conflict in v2.0.2.4

### DIFF
--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -1046,10 +1046,6 @@ func discoverPeers(
 		wg := &sync.WaitGroup{}
 		defer wg.Wait()
 		for peer := range peerChan {
-			if len(h.Network().Peers()) >= 6 {
-				break
-			}
-
 			peer := peer
 			wg.Add(1)
 			go func() {


### PR DESCRIPTION
This PR fixes an accidental regression from the `v2.0.2.3` -> `v2.0.2.4` merge.