### PR TITLE
On demand bootstrap reconnection

### DIFF
--- a/node/p2p/internal/peer_connector.go
+++ b/node/p2p/internal/peer_connector.go
@@ -1,0 +1,307 @@
+package internal
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
+	"go.uber.org/zap"
+)
+
+// PeerConnector is a connector to peers.
+type PeerConnector interface {
+	// Connect connects to peers.
+	Connect(context.Context) error
+}
+
+type peerConnector struct {
+	ctx         context.Context
+	logger      *zap.Logger
+	host        host.Host
+	idService   identify.IDService
+	connectCh   chan (chan<- struct{})
+	minPeers    int
+	parallelism int
+	source      PeerSource
+}
+
+// Connect implements PeerConnector.
+func (pc *peerConnector) Connect(ctx context.Context) error {
+	done := make(chan struct{})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-pc.ctx.Done():
+		return pc.ctx.Err()
+	case pc.connectCh <- done:
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-pc.ctx.Done():
+		return pc.ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
+func (pc *peerConnector) connectToPeer(
+	ctx context.Context,
+	logger *zap.Logger,
+	p peer.AddrInfo,
+	wg *sync.WaitGroup,
+	duplicate, success, failure *uint32,
+	inflight <-chan struct{},
+) {
+	defer func() {
+		select {
+		case <-ctx.Done():
+		case <-inflight:
+		}
+	}()
+	defer wg.Done()
+
+	if p.ID == pc.host.ID() ||
+		pc.host.Network().Connectedness(p.ID) == network.Connected ||
+		pc.host.Network().Connectedness(p.ID) == network.Limited {
+		logger.Debug("peer already connected")
+		atomic.AddUint32(duplicate, 1)
+		return
+	}
+
+	pc.host.Peerstore().AddAddrs(p.ID, p.Addrs, peerstore.AddressTTL)
+
+	conn, err := pc.host.Network().DialPeer(ctx, p.ID)
+	if err != nil {
+		logger.Debug("error while connecting to dht peer", zap.Error(err))
+		atomic.AddUint32(failure, 1)
+		return
+	}
+
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(identify.Timeout / 2):
+		logger.Debug("identifying peer timed out")
+		atomic.AddUint32(failure, 1)
+		_ = conn.Close()
+	case <-pc.idService.IdentifyWait(conn):
+		logger.Debug("connected to peer")
+		atomic.AddUint32(success, 1)
+	}
+}
+
+func (pc *peerConnector) connectToPeers(
+	ctx context.Context,
+	ch <-chan peer.AddrInfo,
+	duplicate, success, failure *uint32,
+) {
+	var inflight chan struct{} = make(chan struct{}, pc.parallelism)
+	var wg sync.WaitGroup
+	for p := range ch {
+		logger := pc.logger.With(zap.String("peer_id", p.ID.String()))
+		logger.Debug("received peer")
+
+		if atomic.LoadUint32(success) >= uint32(pc.minPeers) {
+			logger.Debug("reached max findings")
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case inflight <- struct{}{}:
+		}
+		wg.Add(1)
+		go pc.connectToPeer(
+			ctx,
+			logger,
+			p,
+			&wg,
+			duplicate,
+			success,
+			failure,
+			inflight,
+		)
+	}
+}
+
+func (pc *peerConnector) connect() {
+	logger := pc.logger
+
+	logger.Info("initiating peer connections")
+	var success, failure, duplicate uint32
+	defer func() {
+		logger.Info(
+			"completed peer connections",
+			zap.Uint32("success", success),
+			zap.Uint32("failure", failure),
+			zap.Uint32("duplicate", duplicate),
+		)
+	}()
+	ctx, cancel := context.WithCancel(pc.ctx)
+	defer cancel()
+
+	peerChan, err := pc.source.Peers(ctx)
+	if err != nil {
+		logger.Error("could not find peers", zap.Error(err))
+		return
+	}
+
+	pc.connectToPeers(
+		ctx,
+		peerChan,
+		&duplicate,
+		&success,
+		&failure,
+	)
+}
+
+func (pc *peerConnector) run() {
+	for {
+		select {
+		case <-pc.ctx.Done():
+			return
+		case done := <-pc.connectCh:
+			pc.connect()
+			close(done)
+		}
+	}
+}
+
+// NewPeerConnector creates a new peer connector.
+func NewPeerConnector(
+	ctx context.Context,
+	logger *zap.Logger,
+	host host.Host,
+	idService identify.IDService,
+	minPeers, parallelism int,
+	source PeerSource,
+) PeerConnector {
+	pc := &peerConnector{
+		ctx:         ctx,
+		logger:      logger,
+		host:        host,
+		idService:   idService,
+		connectCh:   make(chan (chan<- struct{})),
+		minPeers:    minPeers,
+		parallelism: parallelism,
+		source:      source,
+	}
+	go pc.run()
+	return pc
+}
+
+type chainedPeerConnector struct {
+	ctx        context.Context
+	connectors []PeerConnector
+	connectCh  chan (chan<- struct{})
+}
+
+// Connect implements PeerConnector.
+func (cpc *chainedPeerConnector) Connect(ctx context.Context) error {
+	done := make(chan struct{})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-cpc.ctx.Done():
+		return cpc.ctx.Err()
+	case cpc.connectCh <- done:
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-cpc.ctx.Done():
+		return cpc.ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
+func (cpc *chainedPeerConnector) run() {
+	for {
+		select {
+		case <-cpc.ctx.Done():
+			return
+		case done := <-cpc.connectCh:
+			for _, pc := range cpc.connectors {
+				_ = pc.Connect(cpc.ctx)
+			}
+			close(done)
+		}
+	}
+}
+
+// NewChainedPeerConnector creates a new chained peer connector.
+func NewChainedPeerConnector(ctx context.Context, connectors ...PeerConnector) PeerConnector {
+	cpc := &chainedPeerConnector{
+		ctx:        ctx,
+		connectors: connectors,
+		connectCh:  make(chan (chan<- struct{})),
+	}
+	go cpc.run()
+	return cpc
+}
+
+type conditionalPeerConnector struct {
+	ctx       context.Context
+	condition PeerConnectorCondition
+	connector PeerConnector
+	connectCh chan (chan<- struct{})
+}
+
+func (cpc *conditionalPeerConnector) run() {
+	for {
+		select {
+		case <-cpc.ctx.Done():
+			return
+		case done := <-cpc.connectCh:
+			if cpc.condition.Should() {
+				_ = cpc.connector.Connect(cpc.ctx)
+			}
+			close(done)
+		}
+	}
+}
+
+// Connect implements PeerConnector.
+func (cpc *conditionalPeerConnector) Connect(ctx context.Context) error {
+	done := make(chan struct{})
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-cpc.ctx.Done():
+		return cpc.ctx.Err()
+	case cpc.connectCh <- done:
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-cpc.ctx.Done():
+		return cpc.ctx.Err()
+	case <-done:
+		return nil
+	}
+}
+
+// NewConditionalPeerConnector creates a new conditional peer connector.
+func NewConditionalPeerConnector(
+	ctx context.Context,
+	condition PeerConnectorCondition,
+	connector PeerConnector,
+) PeerConnector {
+	cpc := &conditionalPeerConnector{
+		ctx:       ctx,
+		condition: condition,
+		connector: connector,
+		connectCh: make(chan (chan<- struct{})),
+	}
+	go cpc.run()
+	return cpc
+}

--- a/node/p2p/internal/peer_connector_condition.go
+++ b/node/p2p/internal/peer_connector_condition.go
@@ -1,0 +1,38 @@
+package internal
+
+import (
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// PeerConnectorCondition is a condition that determines whether a peer connector should connect.
+type PeerConnectorCondition interface {
+	// Should returns true if the peer connector should connect.
+	Should() bool
+}
+
+type notEnoughPeersCondition struct {
+	host     host.Host
+	minPeers int
+	peers    map[peer.ID]struct{}
+}
+
+// Should implements PeerConnectorCondition.
+func (c *notEnoughPeersCondition) Should() bool {
+	count := 0
+	for _, p := range c.host.Network().Peers() {
+		if _, ok := c.peers[p]; ok {
+			count++
+		}
+	}
+	return count < c.minPeers
+}
+
+// NewNotEnoughPeersCondition creates a new not enough peers condition.
+func NewNotEnoughPeersCondition(host host.Host, minPeers int, peers map[peer.ID]struct{}) PeerConnectorCondition {
+	return &notEnoughPeersCondition{
+		host:     host,
+		minPeers: minPeers,
+		peers:    peers,
+	}
+}

--- a/node/p2p/internal/peer_source.go
+++ b/node/p2p/internal/peer_source.go
@@ -1,0 +1,59 @@
+package internal
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/discovery"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/discovery/routing"
+)
+
+// PeerSource is a source of peers.
+type PeerSource interface {
+	// Peers returns a channel of peers.
+	Peers(context.Context) (<-chan peer.AddrInfo, error)
+}
+
+type staticPeerSource struct {
+	peers   []peer.AddrInfo
+	permute bool
+}
+
+// Peers implements PeerSource.
+func (s *staticPeerSource) Peers(context.Context) (<-chan peer.AddrInfo, error) {
+	peers := s.peers
+	if s.permute {
+		peers = Permuted(s.peers)
+	}
+	ch := make(chan peer.AddrInfo, len(peers))
+	for _, p := range peers {
+		ch <- p
+	}
+	close(ch)
+	return ch, nil
+}
+
+// NewStaticPeerSource creates a new static peer source.
+func NewStaticPeerSource(peers []peer.AddrInfo, permute bool) PeerSource {
+	return &staticPeerSource{peers: peers, permute: permute}
+}
+
+type routingDiscoveryPeerSource struct {
+	discovery *routing.RoutingDiscovery
+	namespace string
+	limit     int
+}
+
+// Peers implements PeerSource.
+func (d *routingDiscoveryPeerSource) Peers(ctx context.Context) (<-chan peer.AddrInfo, error) {
+	return d.discovery.FindPeers(ctx, d.namespace, discovery.Limit(d.limit))
+}
+
+// NewRoutingDiscoveryPeerSource creates a new discovery peer source.
+func NewRoutingDiscoveryPeerSource(discovery *routing.RoutingDiscovery, namespace string, limit int) PeerSource {
+	return &routingDiscoveryPeerSource{
+		discovery: discovery,
+		namespace: namespace,
+		limit:     limit,
+	}
+}

--- a/node/p2p/internal/utils.go
+++ b/node/p2p/internal/utils.go
@@ -1,0 +1,41 @@
+package internal
+
+import (
+	"math/rand"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
+)
+
+// PeerAddrInfosToPeerIDSlice converts a slice of peer.AddrInfo to a slice of peer.ID.
+func PeerAddrInfosToPeerIDSlice(p []peer.AddrInfo) []peer.ID {
+	ids := make([]peer.ID, len(p))
+	for i, pi := range p {
+		ids[i] = pi.ID
+	}
+	return ids
+}
+
+// PeerAddrInfosToPeerIDMap converts a slice of peer.AddrInfo to a map of peer.ID.
+func PeerAddrInfosToPeerIDMap(p []peer.AddrInfo) map[peer.ID]struct{} {
+	m := make(map[peer.ID]struct{}, len(p))
+	for _, pi := range p {
+		m[pi.ID] = struct{}{}
+	}
+	return m
+}
+
+// IDServiceFromHost returns the identify.IDService from a host.Host.
+func IDServiceFromHost(h host.Host) identify.IDService {
+	return h.(interface{ IDService() identify.IDService }).IDService()
+}
+
+// Permuted returns a permuted copy of a slice.
+func Permuted[T any](slice []T) []T {
+	permuted := make([]T, len(slice))
+	for i := range rand.Perm(len(slice)) {
+		permuted[i] = slice[i]
+	}
+	return permuted
+}


### PR DESCRIPTION
It's a day that ends in `y`, so we're fixing peering. Today's fixes include:
- Lower the ping timeout to 20 seconds. No connections observed in the wild responded in more than 20 seconds to pings during testing.
- Wait for the connection to be identified after establishing it, in order to increase the odds that it is a fully opened connection.
- Reconnect to bootstrap servers before attempting to do a peer lookup, if we are not connected to at least 3 bootstrap servers.
- Do not protect bootstrap peers. We'll reconnect on demand instead.
- Do not attempt to reconnect to all bootstrap servers, and instead attempt to connect to at least 3 servers. The order of the connections is randomized in order to avoid concentrating load. Every reconnection attempt has another connection order.