### PR TITLE
Trigger automatic peer discovery on frame stall

### DIFF
--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -7,9 +7,11 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math/big"
+	"math/rand"
 	"sync"
 	"time"
 
+	"github.com/libp2p/go-libp2p/p2p/discovery/backoff"
 	"github.com/multiformats/go-multiaddr"
 	mn "github.com/multiformats/go-multiaddr/net"
 	"github.com/pkg/errors"
@@ -337,6 +339,39 @@ func (e *DataClockConsensusEngine) Start() <-chan error {
 	}()
 
 	e.state = consensus.EngineStateCollecting
+
+	go func() {
+		const baseDuration = 2 * time.Minute
+		const maxBackoff = 3
+		var currentBackoff = 0
+		lastHead, err := e.dataTimeReel.Head()
+		if err != nil {
+			panic(err)
+		}
+		source := rand.New(rand.NewSource(rand.Int63()))
+		for e.state < consensus.EngineStateStopping {
+			// Use exponential backoff with jitter in order to avoid hammering the bootstrappers.
+			time.Sleep(
+				backoff.FullJitter(
+					baseDuration<<currentBackoff,
+					baseDuration,
+					baseDuration<<maxBackoff,
+					source,
+				),
+			)
+			currentHead, err := e.dataTimeReel.Head()
+			if err != nil {
+				panic(err)
+			}
+			if currentHead.FrameNumber == lastHead.FrameNumber {
+				currentBackoff = min(maxBackoff, currentBackoff+1)
+				_ = e.pubSub.DiscoverPeers()
+			} else {
+				currentBackoff = max(0, currentBackoff-1)
+				lastHead = currentHead
+			}
+		}
+	}()
 
 	go func() {
 		thresholdBeforeConfirming := 4

--- a/node/consensus/data/token_handle_mint_test.go
+++ b/node/consensus/data/token_handle_mint_test.go
@@ -73,6 +73,7 @@ func (pubsub) GetPeerScore(peerId []byte) int64             { return 0 }
 func (pubsub) SetPeerScore(peerId []byte, score int64)      {}
 func (pubsub) AddPeerScore(peerId []byte, scoreDelta int64) {}
 func (pubsub) Reconnect(peerId []byte) error                { return nil }
+func (pubsub) DiscoverPeers() error                         { return nil }
 
 type outputs struct {
 	difficulty  uint32

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -67,6 +67,7 @@ type BlossomSub struct {
 	peerScore   map[string]int64
 	peerScoreMx sync.Mutex
 	network     uint8
+	discovery   internal.PeerConnector
 }
 
 var _ PubSub = (*BlossomSub)(nil)
@@ -354,6 +355,7 @@ func NewBlossomSub(
 		panic(err)
 	}
 	discovery = internal.NewChainedPeerConnector(ctx, bootstrap, discovery)
+	bs.discovery = discovery
 
 	go monitorPeers(ctx, logger, h)
 
@@ -740,6 +742,10 @@ func (b *BlossomSub) Reconnect(peerId []byte) error {
 
 	b.h.ConnManager().Protect(info.ID, "bootstrap")
 	return nil
+}
+
+func (b *BlossomSub) DiscoverPeers() error {
+	return b.discovery.Connect(b.ctx)
 }
 
 func (b *BlossomSub) GetPeerScore(peerId []byte) int64 {

--- a/node/p2p/pubsub.go
+++ b/node/p2p/pubsub.go
@@ -37,4 +37,5 @@ type PubSub interface {
 	SetPeerScore(peerId []byte, score int64)
 	AddPeerScore(peerId []byte, scoreDelta int64)
 	Reconnect(peerId []byte) error
+	DiscoverPeers() error
 }


### PR DESCRIPTION
References https://github.com/QuilibriumNetwork/ceremonyclient/pull/327

This PR automatically triggers a peer discovery and connection round when the tape head has been stalling for at least 2 minutes. It will then follow an exponential pattern (2 minutes -> 4 minutes -> 8 minutes) of waiting then triggering a new discovery round. Jitter has been added to this wait period in order to avoid hammering the DHT servers excessively.

This mechanism does not replace the PubSub one of ensuring that at least 4 peers are available per bitmask, but instead is meant to bridge the meshes when a partition occurs during steady state. 

It is also slightly slow due to the exponential backoff. We expect that the whole disconnected mesh will run this procedure in order to connect to the remaining mesh - it is not just a node which works towards this, it is the whole disconnected sub-part of the mesh.