### PR TITLE
Lookup peers via DHT

### DIFF
--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -29,6 +29,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/discovery/routing"
 	"github.com/libp2p/go-libp2p/p2p/discovery/util"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
+	routedhost "github.com/libp2p/go-libp2p/p2p/host/routed"
 	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	"github.com/libp2p/go-libp2p/p2p/net/swarm"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
@@ -309,6 +310,7 @@ func NewBlossomSub(
 		isBootstrapPeer,
 		bootstrappers,
 	)
+	h = routedhost.Wrap(h, kademliaDHT)
 
 	routingDiscovery := routing.NewRoutingDiscovery(kademliaDHT)
 	util.Advertise(ctx, routingDiscovery, getNetworkNamespace(p2pConfig.Network))


### PR DESCRIPTION
References https://github.com/QuilibriumNetwork/ceremonyclient/pull/327

This minimalist PR allows the `libp2p` host to lookup peers via the DHT in order to connect to them. The advantage here is that when we receive indirect peers via the peer list announcements, we can lookup their address in the DHT automatically and attempt to synchronize with them.