### PR TITLE
Fix ping period

### DIFF
--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -649,7 +649,7 @@ func (b *BlossomSub) GetRandomPeer(bitmask []byte) ([]byte, error) {
 // up to 3 times to ensure they are still reachable. If the peer is not reachable after
 // 3 attempts, the connections to the peer are closed.
 func monitorPeers(ctx context.Context, logger *zap.Logger, h host.Host) {
-	const timeout, period, attempts = time.Minute, 20 * time.Second, 3
+	const timeout, period, attempts = 20 * time.Second, time.Minute, 3
 	// Do not allow the pings to dial new connections. Adding new peers is a separate
 	// process and should not be done during the ping process.
 	ctx = network.WithNoDial(ctx, "monitor peers")

--- a/node/p2p/internal/peer_connector.go
+++ b/node/p2p/internal/peer_connector.go
@@ -104,6 +104,7 @@ func (pc *peerConnector) connectToPeers(
 ) {
 	var inflight chan struct{} = make(chan struct{}, pc.parallelism)
 	var wg sync.WaitGroup
+	defer wg.Wait()
 	for p := range ch {
 		logger := pc.logger.With(zap.String("peer_id", p.ID.String()))
 		logger.Debug("received peer")


### PR DESCRIPTION
References https://github.com/QuilibriumNetwork/ceremonyclient/pull/327

This PR fixes the ping period to be 1 minute, and the timeout to be 20 seconds, as mentioned in the original PR. It also adds a missing `sync.WaitGroup.Wait` that caused connection goroutines to not be waited for properly.