### PR TITLE
Use node configuration for genesis retrieval

### DIFF
--- a/node/main.go
+++ b/node/main.go
@@ -418,7 +418,7 @@ func main() {
 
 	if *core == 0 {
 		for {
-			genesis, err := config.DownloadAndVerifyGenesis(*network)
+			genesis, err := config.DownloadAndVerifyGenesis(uint(nodeConfig.P2P.Network))
 			if err != nil {
 				time.Sleep(10 * time.Minute)
 				continue


### PR DESCRIPTION
This PR fixes a huge foot gun regarding the active `network` - specifying it via the configuration field `p2p.network` versus using the `-network` CLI parameter. 

Before this PR, if you specified only the configuration field `p2p.network`, but not via the CLI parameter `-network`, you would get something in between - the announcements would go to your `p2p.network`, but the genesis seed and beacon ID would be always the ones of network `0`.