### PR TITLE
Use peer address while checking if date time proofs should be created

### DIFF
--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -20,7 +20,9 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/anypb"
 	"source.quilibrium.com/quilibrium/monorepo/go-libp2p-blossomsub/pb"
 	"source.quilibrium.com/quilibrium/monorepo/node/config"
@@ -37,8 +39,6 @@ import (
 
 const PEER_INFO_TTL = 60 * 60 * 1000
 const UNCOOPERATIVE_PEER_INFO_TTL = 60 * 1000
-
-var ErrNoApplicableChallenge = errors.New("no applicable challenge")
 
 type SyncStatusType int
 
@@ -616,7 +616,7 @@ func (e *DataClockConsensusEngine) PerformTimeProof(
 						},
 					)
 				if err != nil {
-					if errors.Is(err, ErrNoApplicableChallenge) {
+					if status.Code(err) == codes.NotFound {
 						break
 					}
 					if j == 0 {

--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/iden3/go-iden3-crypto/poseidon"
 	pcrypto "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/discovery/backoff"
@@ -509,6 +510,12 @@ func (e *DataClockConsensusEngine) Start() <-chan error {
 	go e.runPreMidnightProofWorker()
 
 	go func() {
+		h, err := poseidon.HashBytes(e.pubSub.GetPeerID())
+		if err != nil {
+			panic(err)
+		}
+		peerProvingKeyAddress := h.FillBytes(make([]byte, 32))
+
 		frame, err := e.dataTimeReel.Head()
 		if err != nil {
 			panic(err)
@@ -551,8 +558,8 @@ func (e *DataClockConsensusEngine) Start() <-chan error {
 			frame = nextFrame
 
 			for i, trie := range e.GetFrameProverTries()[1:] {
-				if trie.Contains(e.provingKeyAddress) {
-					e.logger.Info("creating data shard ring proof", zap.Int("ring", i-1))
+				if trie.Contains(peerProvingKeyAddress) {
+					e.logger.Info("creating data shard ring proof", zap.Int("ring", i))
 					e.PerformTimeProof(frame, frame.Difficulty, clients)
 				}
 			}

--- a/node/rpc/data_worker_ipc_server.go
+++ b/node/rpc/data_worker_ipc_server.go
@@ -11,7 +11,6 @@ import (
 
 	"golang.org/x/crypto/sha3"
 	"source.quilibrium.com/quilibrium/monorepo/node/config"
-	"source.quilibrium.com/quilibrium/monorepo/node/consensus/data"
 	"source.quilibrium.com/quilibrium/monorepo/node/crypto"
 	"source.quilibrium.com/quilibrium/monorepo/node/execution/intrinsics/token"
 	"source.quilibrium.com/quilibrium/monorepo/node/p2p"
@@ -22,7 +21,9 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/reflection"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
 )
@@ -152,10 +153,7 @@ func (r *DataWorkerIPCServer) CalculateChallengeProof(
 	}
 
 	if !found {
-		return nil, errors.Wrap(
-			data.ErrNoApplicableChallenge,
-			"calculate challenge proof",
-		)
+		return nil, status.Error(codes.NotFound, "no applicable challenge")
 	}
 	proof, err := r.prover.CalculateChallengeProof(
 		challenge,


### PR DESCRIPTION
This PR fixes two checks:
- It uses the peer address instead of the proving address to check ring membership.
- It uses gRPC status codes to propagate not found errors.