### PR TITLE
Sample peers which are ahead during sync

### DIFF
--- a/node/consensus/data/internal/peer_candidate.go
+++ b/node/consensus/data/internal/peer_candidate.go
@@ -1,0 +1,25 @@
+package internal
+
+// PeerCandidate is a candidate for a peer to be used for syncing.
+type PeerCandidate struct {
+	PeerID   []byte
+	MaxFrame uint64
+}
+
+// WeightedPeerCandidate is a weighted peer candidate.
+type WeightedPeerCandidate struct {
+	PeerCandidate
+	Weight float64
+}
+
+var _ Weighted[PeerCandidate] = (*WeightedPeerCandidate)(nil)
+
+// GetItem implements Weighted[PeerCandidate].
+func (p WeightedPeerCandidate) GetItem() PeerCandidate {
+	return p.PeerCandidate
+}
+
+// GetWeight implements Weighted[PeerCandidate].
+func (p WeightedPeerCandidate) GetWeight() float64 {
+	return p.Weight
+}

--- a/node/consensus/data/internal/random.go
+++ b/node/consensus/data/internal/random.go
@@ -1,0 +1,69 @@
+package internal
+
+import (
+	"math"
+	"math/rand"
+	"sort"
+)
+
+// Weighted is an interface for items that have a weight.
+type Weighted[T any] interface {
+	GetItem() T
+	GetWeight() float64
+}
+
+type weightedSort[T any] struct {
+	items   []T
+	weights []float64
+}
+
+var _ sort.Interface = (*weightedSort[any])(nil)
+
+// Len implements sort.Interface.
+func (w weightedSort[T]) Len() int {
+	return len(w.items)
+}
+
+// Less implements sort.Interface.
+func (w weightedSort[T]) Less(i, j int) bool {
+	return w.weights[i] >= w.weights[j]
+}
+
+// Swap implements sort.Interface.
+func (w weightedSort[T]) Swap(i, j int) {
+	w.items[i], w.items[j] = w.items[j], w.items[i]
+	w.weights[i], w.weights[j] = w.weights[j], w.weights[i]
+}
+
+// WeightedSampleWithoutReplacementWithSource samples without replacement
+// from a list of weighted items using a given random source.
+// Based on work by Efraimidis and Spirakis.
+func WeightedSampleWithoutReplacementWithSource[T any, W Weighted[T]](
+	items []W,
+	sampleSize int,
+	random *rand.Rand,
+) []T {
+	ws := weightedSort[T]{
+		items:   make([]T, len(items)),
+		weights: make([]float64, len(items)),
+	}
+	for i, item := range items {
+		ws.items[i] = item.GetItem()
+		ws.weights[i] = math.Pow(random.Float64(), 1.0/item.GetWeight())
+	}
+	sort.Sort(ws)
+	return ws.items[:sampleSize]
+}
+
+// WeightedSampleWithoutReplacement samples without replacement from a list
+// of weighted items.
+func WeightedSampleWithoutReplacement[T any, W Weighted[T]](
+	items []W,
+	sampleSize int,
+) []T {
+	return WeightedSampleWithoutReplacementWithSource(
+		items,
+		sampleSize,
+		rand.New(rand.NewSource(rand.Int63())),
+	)
+}

--- a/node/consensus/data/internal/random_test.go
+++ b/node/consensus/data/internal/random_test.go
@@ -1,0 +1,57 @@
+package internal_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"source.quilibrium.com/quilibrium/monorepo/node/consensus/data/internal"
+)
+
+type mockWeighted struct {
+	item   int64
+	weight float64
+}
+
+var _ internal.Weighted[int64] = (*mockWeighted)(nil)
+
+// GetWeight implements Weighted[int64].
+func (m mockWeighted) GetItem() int64 {
+	return m.item
+}
+
+// GetWeight implements Weighted[int64].
+func (m mockWeighted) GetWeight() float64 {
+	return m.weight
+}
+
+func TestWeightedSampleWithoutReplacementWithSource(t *testing.T) {
+	items := []mockWeighted{
+		{item: 0, weight: 0.1},
+		{item: 1, weight: 0.2},
+		{item: 2, weight: 0.4},
+		{item: 3, weight: 0.6},
+		{item: 4, weight: 0.8},
+		{item: 5, weight: 1.0},
+	}
+
+	frequencies := [6]int{}
+	random := rand.New(rand.NewSource(0))
+	for i := 0; i < 10_000; i++ {
+		sample := internal.WeightedSampleWithoutReplacementWithSource(items, 3, random)
+		seen := [6]bool{}
+		for _, item := range sample {
+			assert.False(t, seen[item])
+			frequencies[item]++
+			seen[item] = true
+		}
+	}
+
+	for i := 0; i < 6; i++ {
+		assert.Greater(t, frequencies[i], 0)
+		if i > 0 {
+			assert.Greater(t, frequencies[i], frequencies[i-1])
+		}
+		t.Logf("item %d: %d", i, frequencies[i])
+	}
+}


### PR DESCRIPTION
This PR brings the following changes to the frame syncing process:
- We now look at the _peers_ head instead of the _peer_ ahead. This ensures that we don't re-loop the peer map after every failure.
- We now no longer jump at the highest peer and try to sync with him, but instead look at all of the peers which are ahead of us, and we pick one of them randomly. Peers which are further ahead (frame number wise) are more likely to be tried first before the ones which are closer.