### PR TITLE
Fix BlossomSub raw tracing

### DIFF
--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -420,6 +420,7 @@ func NewBlossomSub(
 
 	params := mergeDefaults(p2pConfig)
 	rt := blossomsub.NewBlossomSubRouter(h, params, bs.network)
+	blossomOpts = append(blossomOpts, rt.WithDefaultTagTracer())
 	pubsub, err := blossomsub.NewBlossomSubWithRouter(ctx, h, rt, blossomOpts...)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
This PR makes the raw tracer of the `BossomSubRouter` to be used by `BlossomSub`. Indirectly this fixes at least the following bugs:
- Direct peers being pruned by the connection manager when the high watermark is hit.
- Normally grafted peers being pruned with the same reason as above.

This happens because the raw tracer is used to `Protect` the peers. But the raw tracer is not injected by default between the `BlossomSubRouter` and the `BlossomSub` itself. `NewBlossomSub` does this on its own, but our construct in `node` does not.

https://github.com/QuilibriumNetwork/ceremonyclient/blob/b0cf294c994a8008e7a62e4d031298d7650bfc0a/go-libp2p-blossomsub/blossomsub.go#L204-L209