### PR TITLE
Fix engine option names

### DIFF
--- a/node/config/engine.go
+++ b/node/config/engine.go
@@ -20,10 +20,10 @@ type EngineConfig struct {
 	DataWorkerMultiaddrs          []string `yaml:"dataWorkerMultiaddrs"`
 	MultisigProverEnrollmentPaths []string `yaml:"multisigProverEnrollmentPaths"`
 	// Fully verifies execution, omit to enable light prover
-	FullProver bool
+	FullProver bool `yaml:"fullProver"`
 	// Automatically merges coins after minting once a sufficient number has been
 	// accrued
-	AutoMergeCoins bool
+	AutoMergeCoins bool `yaml:"autoMergeCoins"`
 
 	// Values used only for testing – do not override these in production, your
 	// node will get kicked out


### PR DESCRIPTION
The new engine options (`fullProver` and `autoMergeCoins`) have the wrong naming and as such are not actually editable. This PR fixes this.

Reproduction available [here](https://play.golang.com/p/6JNxpkCae3L).