### PR TITLE
Ensure latest frame monotonicity

### DIFF
--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -26,6 +26,7 @@ import (
 	qtime "source.quilibrium.com/quilibrium/monorepo/node/consensus/time"
 	qcrypto "source.quilibrium.com/quilibrium/monorepo/node/crypto"
 	"source.quilibrium.com/quilibrium/monorepo/node/execution"
+	"source.quilibrium.com/quilibrium/monorepo/node/internal/cas"
 	"source.quilibrium.com/quilibrium/monorepo/node/keys"
 	"source.quilibrium.com/quilibrium/monorepo/node/p2p"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
@@ -412,7 +413,7 @@ func (e *DataClockConsensusEngine) Start() <-chan error {
 				},
 			}
 
-			e.latestFrameReceived = frame.FrameNumber
+			cas.IfLessThanUint64(&e.latestFrameReceived, frame.FrameNumber)
 			e.logger.Info(
 				"preparing peer announce",
 				zap.Uint64("frame_number", frame.FrameNumber),

--- a/node/consensus/data/main_data_loop.go
+++ b/node/consensus/data/main_data_loop.go
@@ -8,6 +8,7 @@ import (
 	"github.com/iden3/go-iden3-crypto/poseidon"
 	"go.uber.org/zap"
 	"source.quilibrium.com/quilibrium/monorepo/node/consensus"
+	"source.quilibrium.com/quilibrium/monorepo/node/internal/cas"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
 	"source.quilibrium.com/quilibrium/monorepo/node/tries"
 )
@@ -89,9 +90,7 @@ func (e *DataClockConsensusEngine) processFrame(
 		latestFrame = dataFrame
 	}
 
-	if e.latestFrameReceived < latestFrame.FrameNumber {
-		e.latestFrameReceived = latestFrame.FrameNumber
-	}
+	cas.IfLessThanUint64(&e.latestFrameReceived, latestFrame.FrameNumber)
 	e.frameProverTriesMx.Lock()
 	e.frameProverTries = e.dataTimeReel.GetFrameProverTries()
 	e.frameProverTriesMx.Unlock()

--- a/node/internal/cas/cas.go
+++ b/node/internal/cas/cas.go
@@ -1,0 +1,12 @@
+package cas
+
+import "sync/atomic"
+
+// IfLessThanInt64 sets the value of a to lt if the current value of a is less than lt.
+func IfLessThanUint64(a *uint64, lt uint64) {
+	for val := atomic.LoadUint64(a); val < lt; val = atomic.LoadUint64(a) {
+		if atomic.CompareAndSwapUint64(a, val, lt) {
+			return
+		}
+	}
+}


### PR DESCRIPTION
This PR ensures that concurrent writes to the engine latest received frame (`e.latestFrameReceived`) are guaranteed to only increase it. This ensures that weird loops are avoided.