### PR TITLE
Log frame age

### DIFF
--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -27,6 +27,7 @@ import (
 	qcrypto "source.quilibrium.com/quilibrium/monorepo/node/crypto"
 	"source.quilibrium.com/quilibrium/monorepo/node/execution"
 	"source.quilibrium.com/quilibrium/monorepo/node/internal/cas"
+	"source.quilibrium.com/quilibrium/monorepo/node/internal/frametime"
 	"source.quilibrium.com/quilibrium/monorepo/node/keys"
 	"source.quilibrium.com/quilibrium/monorepo/node/p2p"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
@@ -418,6 +419,7 @@ func (e *DataClockConsensusEngine) Start() <-chan error {
 			e.logger.Info(
 				"preparing peer announce",
 				zap.Uint64("frame_number", frame.FrameNumber),
+				zap.Duration("frame_age", frametime.Since(frame)),
 			)
 
 			e.peerMapMx.Lock()
@@ -461,6 +463,7 @@ func (e *DataClockConsensusEngine) Start() <-chan error {
 			e.logger.Info(
 				"broadcasting peer info",
 				zap.Uint64("frame_number", frame.FrameNumber),
+				zap.Duration("frame_age", frametime.Since(frame)),
 			)
 
 			if err := e.publishMessage(e.infoFilter, list); err != nil {
@@ -542,6 +545,8 @@ func (e *DataClockConsensusEngine) PerformTimeProof(
 		"creating data shard ring proof",
 		zap.Int("ring", ring),
 		zap.Int("active_workers", len(actives)),
+		zap.Uint64("frame_number", frame.FrameNumber),
+		zap.Duration("frame_age", frametime.Since(frame)),
 	)
 
 	wg := sync.WaitGroup{}

--- a/node/consensus/data/main_data_loop.go
+++ b/node/consensus/data/main_data_loop.go
@@ -9,6 +9,7 @@ import (
 	"go.uber.org/zap"
 	"source.quilibrium.com/quilibrium/monorepo/node/consensus"
 	"source.quilibrium.com/quilibrium/monorepo/node/internal/cas"
+	"source.quilibrium.com/quilibrium/monorepo/node/internal/frametime"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
 	"source.quilibrium.com/quilibrium/monorepo/node/tries"
 )
@@ -97,6 +98,7 @@ func (e *DataClockConsensusEngine) processFrame(
 	e.logger.Info(
 		"current frame head",
 		zap.Uint64("frame_number", dataFrame.FrameNumber),
+		zap.Duration("frame_age", frametime.Since(dataFrame)),
 	)
 	var err error
 	if !e.GetFrameProverTries()[0].Contains(e.provingKeyBytes) {
@@ -248,6 +250,8 @@ func (e *DataClockConsensusEngine) processFrame(
 					"submitting data proof",
 					zap.Int("ring", ring),
 					zap.Int("active_workers", len(outputs)),
+					zap.Uint64("frame_number", latestFrame.FrameNumber),
+					zap.Duration("frame_age", frametime.Since(latestFrame)),
 				)
 
 				e.publishMessage(e.txFilter, &protobufs.TokenRequest{

--- a/node/execution/intrinsics/token/token_execution_engine.go
+++ b/node/execution/intrinsics/token/token_execution_engine.go
@@ -26,6 +26,7 @@ import (
 	qcrypto "source.quilibrium.com/quilibrium/monorepo/node/crypto"
 	"source.quilibrium.com/quilibrium/monorepo/node/execution"
 	"source.quilibrium.com/quilibrium/monorepo/node/execution/intrinsics/token/application"
+	"source.quilibrium.com/quilibrium/monorepo/node/internal/frametime"
 	"source.quilibrium.com/quilibrium/monorepo/node/keys"
 	"source.quilibrium.com/quilibrium/monorepo/node/p2p"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
@@ -509,6 +510,7 @@ func (e *TokenExecutionEngine) ProcessFrame(
 			"frame_number",
 			frame.FrameNumber,
 		),
+		zap.Duration("frame_age", frametime.Since(frame)),
 	)
 	app, err := application.MaterializeApplicationFromFrame(
 		e.provingKey,

--- a/node/internal/frametime/frametime.go
+++ b/node/internal/frametime/frametime.go
@@ -1,0 +1,12 @@
+package frametime
+
+import (
+	"time"
+
+	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
+)
+
+// Since returns the time elapsed since the given frame was created.
+func Since(frame *protobufs.ClockFrame) time.Duration {
+	return time.Since(time.UnixMilli(frame.Timestamp))
+}


### PR DESCRIPTION
This PR proposes that certain log messages will contain the frame age (i.e. the time elapsed since the frame was minted), in order to assess how far ahead / behind the node and its proofs are.