### PR TITLE
Add sync timeout and make it async

### DIFF
--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -311,7 +311,7 @@ func (e *DataClockConsensusEngine) sync(
 	client := protobufs.NewDataServiceClient(cc)
 
 	for e.GetState() < consensus.EngineStateStopping {
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(e.ctx, 2*time.Second)
 		response, err := client.GetDataFrame(
 			ctx,
 			&protobufs.GetDataFrameRequest{

--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -280,73 +280,65 @@ func (e *DataClockConsensusEngine) sync(
 		zap.Uint64("current_frame", latest.FrameNumber),
 		zap.Uint64("max_frame", maxFrame),
 	)
+	var cooperative bool = true
+	defer func() {
+		if cooperative {
+			return
+		}
+		e.peerMapMx.Lock()
+		defer e.peerMapMx.Unlock()
+		if _, ok := e.peerMap[string(peerId)]; ok {
+			e.uncooperativePeersMap[string(peerId)] = e.peerMap[string(peerId)]
+			e.uncooperativePeersMap[string(peerId)].timestamp = time.Now().UnixMilli()
+			delete(e.peerMap, string(peerId))
+		}
+	}()
 	cc, err := e.pubSub.GetDirectChannel(peerId, "sync")
 	if err != nil {
 		e.logger.Debug(
 			"could not establish direct channel",
 			zap.Error(err),
 		)
-		e.peerMapMx.Lock()
-		if _, ok := e.peerMap[string(peerId)]; ok {
-			e.uncooperativePeersMap[string(peerId)] = e.peerMap[string(peerId)]
-			e.uncooperativePeersMap[string(peerId)].timestamp = time.Now().UnixMilli()
-			delete(e.peerMap, string(peerId))
-		}
-		e.peerMapMx.Unlock()
+		cooperative = false
 		return latest, errors.Wrap(err, "sync")
 	}
+	defer func() {
+		if err := cc.Close(); err != nil {
+			e.logger.Error("error while closing connection", zap.Error(err))
+		}
+	}()
 
 	client := protobufs.NewDataServiceClient(cc)
 
 	for e.GetState() < consensus.EngineStateStopping {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		response, err := client.GetDataFrame(
-			context.TODO(),
+			ctx,
 			&protobufs.GetDataFrameRequest{
 				FrameNumber: latest.FrameNumber + 1,
 			},
 			grpc.MaxCallRecvMsgSize(600*1024*1024),
 		)
+		cancel()
 		if err != nil {
 			e.logger.Debug(
 				"could not get frame",
 				zap.Error(err),
 			)
-			e.peerMapMx.Lock()
-			if _, ok := e.peerMap[string(peerId)]; ok {
-				e.uncooperativePeersMap[string(peerId)] = e.peerMap[string(peerId)]
-				e.uncooperativePeersMap[string(peerId)].timestamp = time.Now().UnixMilli()
-				delete(e.peerMap, string(peerId))
-			}
-			e.peerMapMx.Unlock()
-			if err := cc.Close(); err != nil {
-				e.logger.Error("error while closing connection", zap.Error(err))
-			}
+			cooperative = false
 			return latest, errors.Wrap(err, "sync")
 		}
 
 		if response == nil {
 			e.logger.Debug("received no response from peer")
-			if err := cc.Close(); err != nil {
-				e.logger.Error("error while closing connection", zap.Error(err))
-			}
 			return latest, nil
 		}
 
 		if response.ClockFrame == nil ||
 			response.ClockFrame.FrameNumber != latest.FrameNumber+1 ||
-
 			response.ClockFrame.Timestamp < latest.Timestamp {
 			e.logger.Debug("received invalid response from peer")
-			e.peerMapMx.Lock()
-			if _, ok := e.peerMap[string(peerId)]; ok {
-				e.uncooperativePeersMap[string(peerId)] = e.peerMap[string(peerId)]
-				e.uncooperativePeersMap[string(peerId)].timestamp = time.Now().UnixMilli()
-				delete(e.peerMap, string(peerId))
-			}
-			e.peerMapMx.Unlock()
-			if err := cc.Close(); err != nil {
-				e.logger.Error("error while closing connection", zap.Error(err))
-			}
+			cooperative = false
 			return latest, nil
 		}
 		e.logger.Info(
@@ -357,13 +349,7 @@ func (e *DataClockConsensusEngine) sync(
 		if !e.IsInProverTrie(
 			response.ClockFrame.GetPublicKeySignatureEd448().PublicKey.KeyValue,
 		) {
-			e.peerMapMx.Lock()
-			if _, ok := e.peerMap[string(peerId)]; ok {
-				e.uncooperativePeersMap[string(peerId)] = e.peerMap[string(peerId)]
-				e.uncooperativePeersMap[string(peerId)].timestamp = time.Now().UnixMilli()
-				delete(e.peerMap, string(peerId))
-			}
-			e.peerMapMx.Unlock()
+			cooperative = false
 		}
 		if err := e.frameProver.VerifyDataClockFrame(
 			response.ClockFrame,
@@ -373,11 +359,8 @@ func (e *DataClockConsensusEngine) sync(
 		e.dataTimeReel.Insert(response.ClockFrame, true)
 		latest = response.ClockFrame
 		if latest.FrameNumber >= maxFrame {
-			break
+			return latest, nil
 		}
-	}
-	if err := cc.Close(); err != nil {
-		e.logger.Error("error while closing connection", zap.Error(err))
 	}
 	return latest, nil
 }

--- a/node/consensus/data/peer_messaging.go
+++ b/node/consensus/data/peer_messaging.go
@@ -652,7 +652,7 @@ func (e *DataClockConsensusEngine) GetPublicChannelForProvingKey(
 		}
 		client := protobufs.NewDataServiceClient(cc)
 		s, err := client.GetPublicChannel(
-			context.Background(),
+			e.ctx,
 			grpc.MaxCallSendMsgSize(600*1024*1024),
 			grpc.MaxCallRecvMsgSize(600*1024*1024),
 		)

--- a/node/consensus/data/pre_midnight_proof_worker.go
+++ b/node/consensus/data/pre_midnight_proof_worker.go
@@ -2,7 +2,6 @@ package data
 
 import (
 	"bytes"
-	"context"
 	"encoding/binary"
 	"strings"
 	"time"
@@ -127,7 +126,7 @@ func (e *DataClockConsensusEngine) runPreMidnightProofWorker() {
 
 		if bytes.Equal(resume, make([]byte, 32)) {
 			status, err := client.GetPreMidnightMintStatus(
-				context.Background(),
+				e.ctx,
 				&protobufs.PreMidnightMintStatusRequest{
 					Owner: addr,
 				},
@@ -210,7 +209,7 @@ func (e *DataClockConsensusEngine) runPreMidnightProofWorker() {
 				}
 
 				resp, err := client.HandlePreMidnightMint(
-					context.Background(),
+					e.ctx,
 					&protobufs.MintCoinRequest{
 						Proofs: proofs,
 						Signature: &protobufs.Ed448Signature{


### PR DESCRIPTION
This PR sets a fixed timeout (2 seconds per frame) for `sync` requests towards other peers. While the timeout is quite aggressive, it is meant to speed up the sync process by cutting the time spent on unreachable peers.

It also makes the synchronization asynchronous, by moving it to a dedicated goroutine. The sync may be sporadically triggered, but it won't block the potential arrival of new frames from the PubSub (via the time reel itself).