### PR TITLE
Add sync timeout configuration

### DIFF
--- a/node/config/engine.go
+++ b/node/config/engine.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 type EngineConfig struct {
 	ProvingKeyId         string `yaml:"provingKeyId"`
 	Filter               string `yaml:"filter"`
@@ -28,4 +30,7 @@ type EngineConfig struct {
 	// Values used only for testing – do not override these in production, your
 	// node will get kicked out
 	Difficulty uint32 `yaml:"difficulty"`
+
+	// Maximum wait time for a frame to be downloaded from a peer.
+	SyncTimeout time.Duration `yaml:"syncTimeout"`
 }

--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -20,6 +20,8 @@ import (
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
 )
 
+const defaultSyncTimeout = 2 * time.Second
+
 func (e *DataClockConsensusEngine) collect(
 	enqueuedFrame *protobufs.ClockFrame,
 ) (*protobufs.ClockFrame, error) {
@@ -310,8 +312,13 @@ func (e *DataClockConsensusEngine) sync(
 
 	client := protobufs.NewDataServiceClient(cc)
 
+	syncTimeout := e.config.Engine.SyncTimeout
+	if syncTimeout == 0 {
+		syncTimeout = defaultSyncTimeout
+	}
+
 	for e.GetState() < consensus.EngineStateStopping {
-		ctx, cancel := context.WithTimeout(e.ctx, 2*time.Second)
+		ctx, cancel := context.WithTimeout(e.ctx, syncTimeout)
 		response, err := client.GetDataFrame(
 			ctx,
 			&protobufs.GetDataFrameRequest{


### PR DESCRIPTION
References https://github.com/QuilibriumNetwork/ceremonyclient/pull/352
References https://github.com/QuilibriumNetwork/ceremonyclient/pull/356

This PR adds the sync timeout to the engine configuration.