### PR TITLE
Emit prune event only if meshed

### DIFF
--- a/go-libp2p-blossomsub/blossomsub.go
+++ b/go-libp2p-blossomsub/blossomsub.go
@@ -957,9 +957,12 @@ func (bs *BlossomSubRouter) handlePrune(p peer.ID, ctl *pb.ControlMessage) {
 			continue
 		}
 
-		log.Debugf("PRUNE: Remove mesh link to %s in %s", p, bitmask)
-		bs.tracer.Prune(p, bitmask)
-		delete(peers, p)
+		if _, inMesh := peers[p]; inMesh {
+			log.Debugf("PRUNE: Remove mesh link to %s in %s", p, bitmask)
+			bs.tracer.Prune(p, bitmask)
+			delete(peers, p)
+		}
+
 		// is there a backoff specified by the peer? if so obey it.
 		backoff := prune.GetBackoff()
 		if backoff > 0 {


### PR DESCRIPTION
This PR fixes an issue where the `PRUNE` events were emitted even if the peer sending the prune command was no longer in the mesh (maybe they've pruned us at the same time as we've pruned them, or other inflight issues).

This issue was found via metrics, which in some situations had peer counts go negative (which is obviously impossible). 