### PR TITLE
Avoid BlossomSubRouter race condition

### DIFF
--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -448,6 +448,9 @@ func NewBlossomSub(
 		internal.PeerAddrInfosToPeerIDSlice(bootstrappers),
 		true,
 	)))
+	blossomOpts = append(blossomOpts, blossomsub.WithDiscovery(
+		internal.NewPeerConnectorDiscovery(discovery),
+	))
 
 	params := toBlossomSubParams(p2pConfig)
 	rt := blossomsub.NewBlossomSubRouter(h, params, bs.network)
@@ -462,18 +465,6 @@ func NewBlossomSub(
 	bs.peerID = peerID
 	bs.h = h
 	bs.signKey = privKey
-
-	go func() {
-		for {
-			time.Sleep(30 * time.Second)
-			for _, mask := range pubsub.GetBitmasks() {
-				if !rt.EnoughPeers([]byte(mask), 0) {
-					_ = discovery.Connect(ctx)
-					break
-				}
-			}
-		}
-	}()
 
 	return bs
 }

--- a/node/p2p/internal/discovery.go
+++ b/node/p2p/internal/discovery.go
@@ -1,0 +1,37 @@
+package internal
+
+import (
+	"context"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/discovery"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type peerConnectorDiscovery struct {
+	connector PeerConnector
+}
+
+var _ discovery.Discovery = (*peerConnectorDiscovery)(nil)
+
+// Advertise implements discovery.Advertiser.
+func (d *peerConnectorDiscovery) Advertise(ctx context.Context, ns string, opts ...discovery.Option) (time.Duration, error) {
+	return time.Duration(1<<63 - 1), nil
+}
+
+// FindPeers implements discovery.Discoverer.
+func (d *peerConnectorDiscovery) FindPeers(ctx context.Context, ns string, opts ...discovery.Option) (<-chan peer.AddrInfo, error) {
+	if err := d.connector.Connect(ctx); err != nil {
+		return nil, err
+	}
+	ch := make(chan peer.AddrInfo)
+	close(ch)
+	return ch, nil
+}
+
+// NewPeerConnectorDiscovery creates a new peer connector discovery.
+// The discovery instance does not do any advertisements and just triggers
+// the peer connector once FindPeers is called.
+func NewPeerConnectorDiscovery(connector PeerConnector) discovery.Discovery {
+	return &peerConnectorDiscovery{connector: connector}
+}


### PR DESCRIPTION
This PR fixes the following crash report:

```
{"level":"info","ts":1732009531.5673296,"caller":"master/master_clock_consensus_engine.go:222","msg":"peers in store","peer_store_count":393,"network_peer_count":186}                                                     fatal error: concurrent map read and map write

goroutine 1471 [running]:
source.quilibrium.com/quilibrium/monorepo/go-libp2p-blossomsub.(*BlossomSubRouter).EnoughPeers(0xc012cb9d48, {0xc0084f7ec0, 0x20, 0x0?}, 0x0)                                                                                      /opt/ceremonyclient/go-libp2p-blossomsub/blossomsub.go:674 +0xbb                                                                                                                                                   source.quilibrium.com/quilibrium/monorepo/node/p2p.NewBlossomSub.func2()
        /opt/ceremonyclient/node/p2p/blossomsub.go:470 +0xc8
created by source.quilibrium.com/quilibrium/monorepo/node/p2p.NewBlossomSub in goroutine 1
        /opt/ceremonyclient/node/p2p/blossomsub.go:466 +0x245b
```

Even though they are 'public', we are not really allowed to use the router functions outside of the main PubSub discovery loop. So instead we take another path - we allow the PubSub to do discovery on its own, except it's all mocked and we just trigger a peer lookup when the PubSub tries to find peers. It is the closest variant to 'the scenic route' for now.