### PR TITLE
Use public RPC if gRPC listen address is empty

### DIFF
--- a/client/cmd/root.go
+++ b/client/cmd/root.go
@@ -111,7 +111,11 @@ var rootCmd = &cobra.Command{
 		}
 
 		if publicRPC {
-			fmt.Println("gRPC not enabled, using light node")
+			fmt.Println("Public RPC enabled, using light node")
+			LightNode = true
+		}
+		if !LightNode && NodeConfig.ListenGRPCMultiaddr == "" {
+			fmt.Println("No ListenGRPCMultiaddr found in config, using light node")
 			LightNode = true
 		}
 	},


### PR DESCRIPTION
This PR introduces a fallback for situations in which the `public-rpc` flag is not used, and the gRPC listen address is empty - in such situations, the public RPC is used.