### PR TITLE
Trigger sync on ahead peer

### DIFF
--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -383,7 +383,7 @@ func (e *DataClockConsensusEngine) Start() <-chan error {
 			}
 			if currentHead.FrameNumber == lastHead.FrameNumber {
 				currentBackoff = min(maxBackoff, currentBackoff+1)
-				_ = e.pubSub.DiscoverPeers()
+				_ = e.pubSub.DiscoverPeers(e.ctx)
 			} else {
 				currentBackoff = max(0, currentBackoff-1)
 				lastHead = currentHead

--- a/node/consensus/data/message_handler.go
+++ b/node/consensus/data/message_handler.go
@@ -339,6 +339,13 @@ func (e *DataClockConsensusEngine) handleDataPeerListAnnounce(
 	}
 	e.peerMapMx.Unlock()
 
+	select {
+	case <-e.ctx.Done():
+		return nil
+	case e.requestSyncCh <- nil:
+	default:
+	}
+
 	return nil
 }
 

--- a/node/consensus/data/token_handle_mint_test.go
+++ b/node/consensus/data/token_handle_mint_test.go
@@ -78,7 +78,8 @@ func (pubsub) GetPeerScore(peerId []byte) int64             { return 0 }
 func (pubsub) SetPeerScore(peerId []byte, score int64)      {}
 func (pubsub) AddPeerScore(peerId []byte, scoreDelta int64) {}
 func (pubsub) Reconnect(peerId []byte) error                { return nil }
-func (pubsub) DiscoverPeers() error                         { return nil }
+func (pubsub) Bootstrap(context.Context) error              { return nil }
+func (pubsub) DiscoverPeers(context.Context) error          { return nil }
 
 type outputs struct {
 	difficulty  uint32

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -77,6 +77,7 @@ type BlossomSub struct {
 	peerScore   map[string]int64
 	peerScoreMx sync.Mutex
 	network     uint8
+	bootstrap   internal.PeerConnector
 	discovery   internal.PeerConnector
 }
 
@@ -352,6 +353,7 @@ func NewBlossomSub(
 		),
 		bootstrap,
 	)
+	bs.bootstrap = bootstrap
 
 	discovery := internal.NewPeerConnector(
 		ctx,
@@ -731,8 +733,12 @@ func (b *BlossomSub) Reconnect(peerId []byte) error {
 	return nil
 }
 
-func (b *BlossomSub) DiscoverPeers() error {
-	return b.discovery.Connect(b.ctx)
+func (b *BlossomSub) Bootstrap(ctx context.Context) error {
+	return b.bootstrap.Connect(ctx)
+}
+
+func (b *BlossomSub) DiscoverPeers(ctx context.Context) error {
+	return b.discovery.Connect(ctx)
 }
 
 func (b *BlossomSub) GetPeerScore(peerId []byte) int64 {

--- a/node/p2p/pubsub.go
+++ b/node/p2p/pubsub.go
@@ -52,6 +52,7 @@ type PubSub interface {
 	SetPeerScore(peerId []byte, score int64)
 	AddPeerScore(peerId []byte, scoreDelta int64)
 	Reconnect(peerId []byte) error
-	DiscoverPeers() error
+	Bootstrap(ctx context.Context) error
+	DiscoverPeers(ctx context.Context) error
 	GetNetwork() uint
 }


### PR DESCRIPTION
This PR is a proposal based on [a proposal](https://github.com/QuilibriumNetwork/ceremonyclient/commit/873f4adc7ec02e20d3e7a9ae2d09b63eea09fa2f) I saw in the repository. Basically, once we receive a data peer announcement from a peer which is guaranteed to be ahead of us, we enqueue a sync request. This removes the time triggered behavior of the sync - we only try to sync if someone is ahead, and otherwise we don't do anything else.