### PR TITLE
Disallow excessive GOMAXPROCS

### DIFF
--- a/node/config/engine.go
+++ b/node/config/engine.go
@@ -34,4 +34,6 @@ type EngineConfig struct {
 	// Values used only for testing – do not override these in production, your
 	// node will get kicked out
 	Difficulty uint32 `yaml:"difficulty"`
+	// Whether to allow GOMAXPROCS values above the number of physical cores.
+	AllowExcessiveGOMAXPROCS bool `yaml:"allowExcessiveGOMAXPROCS"`
 }

--- a/node/main.go
+++ b/node/main.go
@@ -394,6 +394,12 @@ func main() {
 		nodeConfig.Engine.DataWorkerMemoryLimit = 1792 * 1024 * 1024 // 1.75GiB
 	}
 	if len(nodeConfig.Engine.DataWorkerMultiaddrs) == 0 {
+		maxProcs, numCPU := runtime.GOMAXPROCS(0), runtime.NumCPU()
+		if maxProcs > numCPU && !nodeConfig.Engine.AllowExcessiveGOMAXPROCS {
+			fmt.Println("GOMAXPROCS is set higher than the number of available CPUs.")
+			os.Exit(1)
+		}
+
 		nodeConfig.Engine.DataWorkerCount = qruntime.WorkerCount(
 			nodeConfig.Engine.DataWorkerCount, true,
 		)


### PR DESCRIPTION
This PR proposes that nodes without external data workers which have `GOMAXPROCS` above the available number of CPUs on the machine error out on start. This behavior can be turned off for testing purposes via the engine `allowExcessiveGOMAXPROCS` configuration.

The rationale is that certain nodes in the wild are either intentionally or accidentally using `GOMAXPROCS` > `runtime.NumCPU()` in order to have more workers than physical cores. This leads to over commitment of CPU resources and does not allow the network stack to run while frames are being proven.