### PR TITLE
Increase default sync timeout to 4 seconds

### DIFF
--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -20,7 +20,7 @@ import (
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
 )
 
-const defaultSyncTimeout = 2 * time.Second
+const defaultSyncTimeout = 4 * time.Second
 
 func (e *DataClockConsensusEngine) collect(
 	enqueuedFrame *protobufs.ClockFrame,


### PR DESCRIPTION
This PR changes the default sync timeout to 4 seconds. We have been receiving reports that the 2 second timeout is too aggressive for now. Users which did not encounter issues with the 2 second timeout can revert this change via config.