### PR TITLE
Release buffers in edge cases

### DIFF
--- a/go-libp2p-blossomsub/comm.go
+++ b/go-libp2p-blossomsub/comm.go
@@ -77,6 +77,7 @@ func (p *PubSub) handleNewStream(s network.Stream) {
 			return
 		}
 		if len(msgbytes) == 0 {
+			r.ReleaseMsg(msgbytes)
 			continue
 		}
 
@@ -186,18 +187,18 @@ func (p *PubSub) handleSendingMessages(ctx context.Context, s network.Stream, ou
 				s.Reset()
 				log.Debugf("writing message to %s: %s", s.Conn().RemotePeer(), err)
 				s.Close()
+				pool.Put(buf)
 				return
 			}
 
 			_, err = s.Write(buf)
+			pool.Put(buf)
 			if err != nil {
 				s.Reset()
 				log.Debugf("writing message to %s: %s", s.Conn().RemotePeer(), err)
 				s.Close()
 				return
 			}
-
-			pool.Put(buf)
 		case <-ctx.Done():
 			s.Close()
 			return


### PR DESCRIPTION
This PR releases the send and receive buffers used in `blossomsub` in some edge cases (errors, empty reads). This is a regression from the 1.4.19.1 release caused by the aggressive removal of defers.

![image](https://github.com/user-attachments/assets/bb61bcbe-dd08-4a9f-9b94-11fdb94669af)
