### PR TITLE
Optimise token request duplicate handling

### DIFF
--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -61,7 +61,6 @@ func (e *DataClockConsensusEngine) prove(
 	if e.lastProven >= previousFrame.FrameNumber && e.lastProven != 0 {
 		return previousFrame, nil
 	}
-	e.stagedTransactionsMx.Lock()
 	executionOutput := &protobufs.IntrinsicExecutionOutput{}
 	_, tries, err := e.clockStore.GetDataClockFrame(
 		e.filter,
@@ -78,31 +77,33 @@ func (e *DataClockConsensusEngine) prove(
 		e.logger,
 	)
 	if err != nil {
-		e.stagedTransactionsMx.Unlock()
 		return nil, errors.Wrap(err, "prove")
 	}
 
-	if e.stagedTransactions == nil {
-		e.stagedTransactions = &protobufs.TokenRequests{}
-		e.stagedTransactionsSet = make(map[string]struct{})
+	e.stagedTransactionsMx.Lock()
+	stagedTransactions := e.stagedTransactions
+	if stagedTransactions == nil {
+		stagedTransactions = &protobufs.TokenRequests{}
 	}
+	e.stagedTransactions = &protobufs.TokenRequests{
+		Requests: make([]*protobufs.TokenRequest, 0, len(stagedTransactions.Requests)),
+	}
+	e.stagedTransactionsSet = make(map[string]struct{}, len(e.stagedTransactionsSet))
+	e.stagedTransactionsMx.Unlock()
 
 	e.logger.Info(
 		"proving new frame",
-		zap.Int("transactions", len(e.stagedTransactions.Requests)),
+		zap.Int("transactions", len(stagedTransactions.Requests)),
 	)
 
 	var validTransactions *protobufs.TokenRequests
 	var invalidTransactions *protobufs.TokenRequests
 	app, validTransactions, invalidTransactions, err = app.ApplyTransitions(
 		previousFrame.FrameNumber+1,
-		e.stagedTransactions,
+		stagedTransactions,
 		true,
 	)
 	if err != nil {
-		e.stagedTransactions = &protobufs.TokenRequests{}
-		e.stagedTransactionsSet = make(map[string]struct{})
-		e.stagedTransactionsMx.Unlock()
 		return nil, errors.Wrap(err, "prove")
 	}
 
@@ -111,9 +112,6 @@ func (e *DataClockConsensusEngine) prove(
 		zap.Int("successful", len(validTransactions.Requests)),
 		zap.Int("failed", len(invalidTransactions.Requests)),
 	)
-	e.stagedTransactions = &protobufs.TokenRequests{}
-	e.stagedTransactionsSet = make(map[string]struct{})
-	e.stagedTransactionsMx.Unlock()
 
 	outputState, err := app.MaterializeStateFromApplication()
 	if err != nil {

--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -84,6 +84,7 @@ func (e *DataClockConsensusEngine) prove(
 
 	if e.stagedTransactions == nil {
 		e.stagedTransactions = &protobufs.TokenRequests{}
+		e.stagedTransactionsSet = make(map[string]struct{})
 	}
 
 	e.logger.Info(
@@ -100,6 +101,7 @@ func (e *DataClockConsensusEngine) prove(
 	)
 	if err != nil {
 		e.stagedTransactions = &protobufs.TokenRequests{}
+		e.stagedTransactionsSet = make(map[string]struct{})
 		e.stagedTransactionsMx.Unlock()
 		return nil, errors.Wrap(err, "prove")
 	}
@@ -110,6 +112,7 @@ func (e *DataClockConsensusEngine) prove(
 		zap.Int("failed", len(invalidTransactions.Requests)),
 	)
 	e.stagedTransactions = &protobufs.TokenRequests{}
+	e.stagedTransactionsSet = make(map[string]struct{})
 	e.stagedTransactionsMx.Unlock()
 
 	outputState, err := app.MaterializeStateFromApplication()

--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -116,6 +116,7 @@ type DataClockConsensusEngine struct {
 	engineMx                       sync.Mutex
 	dependencyMapMx                sync.Mutex
 	stagedTransactions             *protobufs.TokenRequests
+	stagedTransactionsSet          map[string]struct{}
 	stagedTransactionsMx           sync.Mutex
 	peerMapMx                      sync.RWMutex
 	peerAnnounceMapMx              sync.Mutex


### PR DESCRIPTION
This PR optimizes the token request handling to avoid a full traversal of the staged transactions list, instead opting for a map lookup. It also releases the staged transactions lock significantly earlier in order to allow the transactions loop to keep appending pending transactions.