### PR TITLE
Add structured stop procedure

### DIFF
--- a/node/consensus/data/main_data_loop.go
+++ b/node/consensus/data/main_data_loop.go
@@ -43,6 +43,7 @@ func (
 }
 
 func (e *DataClockConsensusEngine) runFramePruning() {
+	defer e.wg.Done()
 	// A full prover should _never_ do this
 	if e.GetFrameProverTries()[0].Contains(e.provingKeyAddress) ||
 		e.config.Engine.MaxFrames == -1 || e.config.Engine.FullProver {
@@ -85,6 +86,7 @@ func (e *DataClockConsensusEngine) runFramePruning() {
 }
 
 func (e *DataClockConsensusEngine) runSync() {
+	defer e.wg.Done()
 	// small optimization, beacon should never collect for now:
 	if e.GetFrameProverTries()[0].Contains(e.provingKeyAddress) {
 		return
@@ -113,6 +115,7 @@ func (e *DataClockConsensusEngine) runSync() {
 }
 
 func (e *DataClockConsensusEngine) runLoop() {
+	defer e.wg.Done()
 	dataFrameCh := e.dataTimeReel.NewFrameCh()
 	runOnce := true
 	for {

--- a/node/consensus/data/message_handler.go
+++ b/node/consensus/data/message_handler.go
@@ -19,6 +19,7 @@ import (
 )
 
 func (e *DataClockConsensusEngine) runFrameMessageHandler() {
+	defer e.wg.Done()
 	for {
 		select {
 		case <-e.ctx.Done():
@@ -67,6 +68,7 @@ func (e *DataClockConsensusEngine) runFrameMessageHandler() {
 }
 
 func (e *DataClockConsensusEngine) runTxMessageHandler() {
+	defer e.wg.Done()
 	for {
 		select {
 		case <-e.ctx.Done():
@@ -155,6 +157,7 @@ func (e *DataClockConsensusEngine) runTxMessageHandler() {
 }
 
 func (e *DataClockConsensusEngine) runInfoMessageHandler() {
+	defer e.wg.Done()
 	for {
 		select {
 		case <-e.ctx.Done():

--- a/node/consensus/time/data_time_reel.go
+++ b/node/consensus/time/data_time_reel.go
@@ -36,6 +36,7 @@ type DataTimeReel struct {
 
 	ctx    context.Context
 	cancel context.CancelFunc
+	wg     sync.WaitGroup
 
 	filter       []byte
 	engineConfig *config.EngineConfig
@@ -175,6 +176,7 @@ func (d *DataTimeReel) Start() error {
 		d.headDistance, err = d.GetDistance(frame)
 	}
 
+	d.wg.Add(1)
 	go d.runLoop()
 
 	return nil
@@ -253,6 +255,7 @@ func (d *DataTimeReel) BadFrameCh() <-chan *protobufs.ClockFrame {
 
 func (d *DataTimeReel) Stop() {
 	d.cancel()
+	d.wg.Wait()
 }
 
 func (d *DataTimeReel) createGenesisFrame() (
@@ -338,6 +341,7 @@ func (d *DataTimeReel) createGenesisFrame() (
 
 // Main data consensus loop
 func (d *DataTimeReel) runLoop() {
+	defer d.wg.Done()
 	for {
 		select {
 		case <-d.ctx.Done():


### PR DESCRIPTION
This PR adds some structure to how goroutines are started and how it interacts with the `Stop` of different components. In short:
- When we spawn a goroutine for a struct member function, we `wg.Add(1)` (or N for N).
- When we finish that goroutine we `wg.Done`.
- When we stop, we cancel the component context and do `wg.Wait`.
Why bother ? Because these background goroutines could still use Pebble and it's good to make sure they're all finished up before trying to close Pebble and run into trouble.

The context structure is not ideal yet (every component derives from `context.Background`), but that can be fixed in another PR.