### PR TITLE
Revert blossomsub flooding

### DIFF
--- a/go-libp2p-blossomsub/blossomsub.go
+++ b/go-libp2p-blossomsub/blossomsub.go
@@ -1182,20 +1182,7 @@ func (bs *BlossomSubRouter) Publish(msg *Message) {
 	bitmask := msg.GetBitmask()
 
 	tosend := make(map[peer.ID]struct{})
-
-	sliced := SliceBitmask(bitmask)
-	// bloom publish:
-	if len(sliced) != 1 {
-		// any peers in all slices of the bitmask?
-		peers := bs.p.getPeersInBitmask(bitmask)
-		if len(peers) == 0 {
-			return
-		}
-
-		for _, p := range peers {
-			tosend[p] = struct{}{}
-		}
-	} else { // classic gossip mesh
+	for _, bitmask := range SliceBitmask(bitmask) {
 		// any peers in the bitmask?
 		tmap, ok := bs.p.bitmasks[string(bitmask)]
 		if !ok {

--- a/go-libp2p-blossomsub/blossomsub.go
+++ b/go-libp2p-blossomsub/blossomsub.go
@@ -1180,9 +1180,13 @@ func (bs *BlossomSubRouter) Publish(msg *Message) {
 
 	from := msg.ReceivedFrom
 	bitmask := msg.GetBitmask()
+	originalSender := peer.ID(msg.GetFrom())
+	mid := string(bs.p.idGen.ID(msg))
 
-	tosend := make(map[peer.ID]struct{})
+	var toSendAll []map[peer.ID]struct{}
 	for _, bitmask := range SliceBitmask(bitmask) {
+		tosend := make(map[peer.ID]struct{})
+
 		// any peers in the bitmask?
 		tmap, ok := bs.p.bitmasks[string(bitmask)]
 		if !ok {
@@ -1236,21 +1240,27 @@ func (bs *BlossomSubRouter) Publish(msg *Message) {
 				tosend[p] = struct{}{}
 			}
 		}
+
+		delete(tosend, from)
+		delete(tosend, originalSender)
+		for p := range tosend {
+			if _, ok := bs.unwanted[p][mid]; ok {
+				delete(tosend, p)
+			}
+		}
+
+		if len(tosend) > 0 {
+			toSendAll = append(toSendAll, tosend)
+		}
 	}
 
+	if len(toSendAll) == 0 {
+		return
+	}
+	toSend := toSendAll[rand.Intn(len(toSendAll))]
+
 	out := rpcWithMessages(msg.Message)
-	for pid := range tosend {
-		if pid == from || pid == peer.ID(msg.GetFrom()) {
-			continue
-		}
-
-		mid := bs.p.idGen.ID(msg)
-		// Check if it has already received an IDONTWANT for the message.
-		// If so, don't send it to the peer
-		if _, ok := bs.unwanted[pid][string(mid)]; ok {
-			continue
-		}
-
+	for pid := range toSend {
 		bs.sendRPC(pid, out, false)
 	}
 }


### PR DESCRIPTION
Currently publishing messages in bitmasks which have more than 1 bit set result in calls to `getPeersInBitmask`. `getPeersInBitmask` looks at the peers interested (i.e. subscribed) to the sliced bitmasks, not the peers which are part of the mesh (i.e. grafted).

All of the nodes in the network are subscribed to the same topics, so `getPeersInBitmask` is actually just equivalent to the full list of peers to which the node is connected.

This PR proposes that instead we pick one of the bloom filters and fan out to the mesh associated with that bloom filter.