### PR TITLE
Reintroduce blossomsub GossipFactor

### DIFF
--- a/go-libp2p-blossomsub/blossomsub.go
+++ b/go-libp2p-blossomsub/blossomsub.go
@@ -40,6 +40,7 @@ var (
 	BlossomSubHistoryLength                    = 5
 	BlossomSubHistoryGossip                    = 3
 	BlossomSubDlazy                            = 6
+	BlossomSubGossipFactor                     = 0.25
 	BlossomSubGossipRetransmission             = 3
 	BlossomSubBitmaskWidth                     = 256
 	BlossomSubHeartbeatInitialDelay            = 100 * time.Millisecond
@@ -116,8 +117,14 @@ type BlossomSubParams struct {
 
 	// Dlazy affects how many peers we will emit gossip to at each heartbeat.
 	// We will send gossip to at least Dlazy peers outside our mesh. The actual
-	// number may be less, depending on how many peers we're connected to.
+	// number may be more, depending on GossipFactor and how many peers we're
+	// connected to.
 	Dlazy int
+
+	// GossipFactor affects how many peers we will emit gossip to at each heartbeat.
+	// We will send gossip to GossipFactor * (total number of non-mesh peers), or
+	// Dlazy, whichever is greater.
+	GossipFactor float64
 
 	// GossipRetransmission controls how many times we will allow a peer to request
 	// the same message id through IWANT gossip before we start ignoring them. This is designed
@@ -313,6 +320,7 @@ func DefaultBlossomSubParams() BlossomSubParams {
 		HistoryLength:             BlossomSubHistoryLength,
 		HistoryGossip:             BlossomSubHistoryGossip,
 		Dlazy:                     BlossomSubDlazy,
+		GossipFactor:              BlossomSubGossipFactor,
 		GossipRetransmission:      BlossomSubGossipRetransmission,
 		HeartbeatInitialDelay:     BlossomSubHeartbeatInitialDelay,
 		HeartbeatInterval:         BlossomSubHeartbeatInterval,
@@ -1991,6 +1999,8 @@ func (bs *BlossomSubRouter) emitGossip(bitmask []byte, exclude map[peer.ID]struc
 	}
 
 	target := bs.params.Dlazy
+	factor := int(bs.params.GossipFactor * float64(len(peers)))
+	target = max(target, factor)
 
 	if target > len(peers) {
 		target = len(peers)

--- a/node/config/p2p.go
+++ b/node/config/p2p.go
@@ -13,6 +13,7 @@ type P2PConfig struct {
 	HistoryLength             int           `yaml:"historyLength"`
 	HistoryGossip             int           `yaml:"historyGossip"`
 	DLazy                     int           `yaml:"dLazy"`
+	GossipFactor              float64       `yaml:"gossipFactor"`
 	GossipRetransmission      int           `yaml:"gossipRetransmission"`
 	HeartbeatInitialDelay     time.Duration `yaml:"heartbeatInitialDelay"`
 	HeartbeatInterval         time.Duration `yaml:"heartbeatInterval"`

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -979,6 +979,9 @@ func withDefaults(p2pConfig *config.P2PConfig) *config.P2PConfig {
 	if p2pConfig.DLazy == 0 {
 		p2pConfig.DLazy = blossomsub.BlossomSubDlazy
 	}
+	if p2pConfig.GossipFactor == 0 {
+		p2pConfig.GossipFactor = blossomsub.BlossomSubGossipFactor
+	}
 	if p2pConfig.GossipRetransmission == 0 {
 		p2pConfig.GossipRetransmission = blossomsub.BlossomSubGossipRetransmission
 	}
@@ -1091,6 +1094,7 @@ func toBlossomSubParams(p2pConfig *config.P2PConfig) blossomsub.BlossomSubParams
 		HistoryLength:             p2pConfig.HistoryLength,
 		HistoryGossip:             p2pConfig.HistoryGossip,
 		Dlazy:                     p2pConfig.DLazy,
+		GossipFactor:              p2pConfig.GossipFactor,
 		GossipRetransmission:      p2pConfig.GossipRetransmission,
 		HeartbeatInitialDelay:     p2pConfig.HeartbeatInitialDelay,
 		HeartbeatInterval:         p2pConfig.HeartbeatInterval,


### PR DESCRIPTION
This PR proposes the reintroduction of the `GossipFactor` parameter, in order to allow gossip messages to be sent to more than just 6 peers which are not part of the mesh.