### PR TITLE
Increase default maximum message size to 20MiB

### DIFF
--- a/go-libp2p-blossomsub/pubsub.go
+++ b/go-libp2p-blossomsub/pubsub.go
@@ -26,8 +26,8 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 )
 
-// DefaultMaximumMessageSize is 10 MB.
-const DefaultMaxMessageSize = 10 << 20
+// DefaultMaximumMessageSize is 20 MB.
+const DefaultMaxMessageSize = 10 << 21
 
 var (
 	// TimeCacheDuration specifies how long a message ID will be remembered as seen.


### PR DESCRIPTION
This PR proposes increasing the PubSub default maximum message size to 20MiB preemptively, as frames are already close to the current limit of 10 MiB.

This change however is moderately risky, as un-updated nodes may drop these large messages. We will need a cutoff version (maybe dynamic - return 2.0.4 for 24 hours after the cutoff date, then 2.0.5).