### PR TITLE
Always start sync from head

### DIFF
--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -21,12 +21,13 @@ import (
 
 const defaultSyncTimeout = 4 * time.Second
 
-func (e *DataClockConsensusEngine) collect(
-	enqueuedFrame *protobufs.ClockFrame,
-) (*protobufs.ClockFrame, error) {
+func (e *DataClockConsensusEngine) syncWithMesh() error {
 	e.logger.Info("collecting vdf proofs")
 
-	latest := enqueuedFrame
+	latest, err := e.dataTimeReel.Head()
+	if err != nil {
+		return errors.Wrap(err, "sync")
+	}
 	for {
 		candidates := e.GetAheadPeers(max(latest.FrameNumber, e.latestFrameReceived))
 		if len(candidates) == 0 {
@@ -37,7 +38,7 @@ func (e *DataClockConsensusEngine) collect(
 				continue
 			}
 			var err error
-			latest, err = e.sync(latest, candidate.MaxFrame, candidate.PeerID)
+			latest, err = e.syncWithPeer(latest, candidate.MaxFrame, candidate.PeerID)
 			if err != nil {
 				e.logger.Debug("error syncing frame", zap.Error(err))
 				continue
@@ -51,7 +52,7 @@ func (e *DataClockConsensusEngine) collect(
 		zap.Duration("frame_age", frametime.Since(latest)),
 	)
 
-	return latest, nil
+	return nil
 }
 
 func (e *DataClockConsensusEngine) prove(
@@ -268,7 +269,7 @@ func (e *DataClockConsensusEngine) GetAheadPeers(frameNumber uint64) []internal.
 	return internal.WeightedSampleWithoutReplacement(candidates, len(candidates))
 }
 
-func (e *DataClockConsensusEngine) sync(
+func (e *DataClockConsensusEngine) syncWithPeer(
 	currentLatest *protobufs.ClockFrame,
 	maxFrame uint64,
 	peerId []byte,

--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -37,11 +37,16 @@ func (e *DataClockConsensusEngine) syncWithMesh() error {
 			if candidate.MaxFrame <= max(latest.FrameNumber, e.latestFrameReceived) {
 				continue
 			}
-			var err error
+			head, err := e.dataTimeReel.Head()
+			if err != nil {
+				return errors.Wrap(err, "sync")
+			}
+			if latest.FrameNumber < head.FrameNumber {
+				latest = head
+			}
 			latest, err = e.syncWithPeer(latest, candidate.MaxFrame, candidate.PeerID)
 			if err != nil {
 				e.logger.Debug("error syncing frame", zap.Error(err))
-				continue
 			}
 		}
 	}

--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -135,7 +135,7 @@ type DataClockConsensusEngine struct {
 	previousFrameProven            *protobufs.ClockFrame
 	previousTree                   *mt.MerkleTree
 	clientReconnectTest            int
-	requestSyncCh                  chan *protobufs.ClockFrame
+	requestSyncCh                  chan struct{}
 }
 
 var _ consensus.DataConsensusEngine = (*DataClockConsensusEngine)(nil)
@@ -269,7 +269,7 @@ func NewDataClockConsensusEngine(
 			rateLimit,
 			time.Minute,
 		),
-		requestSyncCh: make(chan *protobufs.ClockFrame, 1),
+		requestSyncCh: make(chan struct{}, 1),
 	}
 
 	logger.Info("constructing consensus engine")

--- a/node/consensus/data/message_handler.go
+++ b/node/consensus/data/message_handler.go
@@ -352,7 +352,7 @@ func (e *DataClockConsensusEngine) handleDataPeerListAnnounce(
 	select {
 	case <-e.ctx.Done():
 		return nil
-	case e.requestSyncCh <- nil:
+	case e.requestSyncCh <- struct{}{}:
 	default:
 	}
 


### PR DESCRIPTION
This PR simplifies the sync procedure to always start from the head of the data time reel, instead of a starting frame. The reason for this is that at the moment the data time reel head is always the 'furthest point in time'. This should avoid sync procedures that start in the past.