### PR TITLE
Add transaction request validation

### DIFF
--- a/client/cmd/proverPause.go
+++ b/client/cmd/proverPause.go
@@ -98,19 +98,19 @@ func publishMessage(
 	filter []byte,
 	message proto.Message,
 ) error {
-	any := &anypb.Any{}
-	if err := any.MarshalFrom(message); err != nil {
+	a := &anypb.Any{}
+	if err := a.MarshalFrom(message); err != nil {
 		return errors.Wrap(err, "publish message")
 	}
 
-	any.TypeUrl = strings.Replace(
-		any.TypeUrl,
+	a.TypeUrl = strings.Replace(
+		a.TypeUrl,
 		"type.googleapis.com",
 		"types.quilibrium.com",
 		1,
 	)
 
-	payload, err := proto.Marshal(any)
+	payload, err := proto.Marshal(a)
 	if err != nil {
 		return errors.Wrap(err, "publish message")
 	}

--- a/node/consensus/data/broadcast_messaging.go
+++ b/node/consensus/data/broadcast_messaging.go
@@ -102,19 +102,19 @@ func (e *DataClockConsensusEngine) insertTxMessage(
 	filter []byte,
 	message proto.Message,
 ) error {
-	any := &anypb.Any{}
-	if err := any.MarshalFrom(message); err != nil {
+	a := &anypb.Any{}
+	if err := a.MarshalFrom(message); err != nil {
 		return errors.Wrap(err, "publish message")
 	}
 
-	any.TypeUrl = strings.Replace(
-		any.TypeUrl,
+	a.TypeUrl = strings.Replace(
+		a.TypeUrl,
 		"type.googleapis.com",
 		"types.quilibrium.com",
 		1,
 	)
 
-	payload, err := proto.Marshal(any)
+	payload, err := proto.Marshal(a)
 	if err != nil {
 		return errors.Wrap(err, "publish message")
 	}
@@ -156,19 +156,19 @@ func (e *DataClockConsensusEngine) publishMessage(
 	filter []byte,
 	message proto.Message,
 ) error {
-	any := &anypb.Any{}
-	if err := any.MarshalFrom(message); err != nil {
+	a := &anypb.Any{}
+	if err := a.MarshalFrom(message); err != nil {
 		return errors.Wrap(err, "publish message")
 	}
 
-	any.TypeUrl = strings.Replace(
-		any.TypeUrl,
+	a.TypeUrl = strings.Replace(
+		a.TypeUrl,
 		"type.googleapis.com",
 		"types.quilibrium.com",
 		1,
 	)
 
-	payload, err := proto.Marshal(any)
+	payload, err := proto.Marshal(a)
 	if err != nil {
 		return errors.Wrap(err, "publish message")
 	}

--- a/node/consensus/data/message_handler.go
+++ b/node/consensus/data/message_handler.go
@@ -34,31 +34,18 @@ func (e *DataClockConsensusEngine) runFrameMessageHandler() {
 				continue
 			}
 
-			any := &anypb.Any{}
-			if err := proto.Unmarshal(msg.Payload, any); err != nil {
+			a := &anypb.Any{}
+			if err := proto.Unmarshal(msg.Payload, a); err != nil {
 				e.logger.Error("error while unmarshaling", zap.Error(err))
 				continue
 			}
 
-			accepted := false
-			switch any.TypeUrl {
-			//expand for future message types
-			case protobufs.ClockFrameType:
-				accepted = true
-			default:
-			}
-
-			if !accepted {
-				e.pubSub.AddPeerScore(message.From, -100000)
-				continue
-			}
-
-			switch any.TypeUrl {
+			switch a.TypeUrl {
 			case protobufs.ClockFrameType:
 				if err := e.handleClockFrameData(
 					message.From,
 					msg.Address,
-					any,
+					a,
 					false,
 				); err != nil {
 					e.logger.Debug("could not handle clock frame data", zap.Error(err))
@@ -83,21 +70,8 @@ func (e *DataClockConsensusEngine) runTxMessageHandler() {
 				continue
 			}
 
-			any := &anypb.Any{}
-			if err := proto.Unmarshal(msg.Payload, any); err != nil {
-				continue
-			}
-
-			accepted := false
-			switch any.TypeUrl {
-			//expand for future message types
-			case protobufs.TokenRequestType:
-				accepted = true
-			default:
-			}
-
-			if !accepted {
-				e.pubSub.AddPeerScore(message.From, -100000)
+			a := &anypb.Any{}
+			if err := proto.Unmarshal(msg.Payload, a); err != nil {
 				continue
 			}
 
@@ -122,8 +96,8 @@ func (e *DataClockConsensusEngine) runTxMessageHandler() {
 						}
 
 						for _, appMessage := range messages {
-							appMsg := &anypb.Any{}
-							err := proto.Unmarshal(appMessage.Payload, appMsg)
+							a := &anypb.Any{}
+							err := proto.Unmarshal(appMessage.Payload, a)
 							if err != nil {
 								e.logger.Error(
 									"could not unmarshal app message",
@@ -133,10 +107,10 @@ func (e *DataClockConsensusEngine) runTxMessageHandler() {
 								continue
 							}
 
-							switch appMsg.TypeUrl {
+							switch a.TypeUrl {
 							case protobufs.TokenRequestType:
 								t := &protobufs.TokenRequest{}
-								err := proto.Unmarshal(appMsg.Value, t)
+								err := proto.Unmarshal(a.Value, t)
 								if err != nil {
 									e.logger.Debug("could not unmarshal token request", zap.Error(err))
 									continue
@@ -172,31 +146,18 @@ func (e *DataClockConsensusEngine) runInfoMessageHandler() {
 				continue
 			}
 
-			any := &anypb.Any{}
-			if err := proto.Unmarshal(msg.Payload, any); err != nil {
+			a := &anypb.Any{}
+			if err := proto.Unmarshal(msg.Payload, a); err != nil {
 				e.logger.Error("error while unmarshaling", zap.Error(err))
 				continue
 			}
 
-			accepted := false
-			switch any.TypeUrl {
-			//expand for future message types
-			case protobufs.DataPeerListAnnounceType:
-				accepted = true
-			default:
-			}
-
-			if !accepted {
-				e.pubSub.AddPeerScore(message.From, -100000)
-				continue
-			}
-
-			switch any.TypeUrl {
+			switch a.TypeUrl {
 			case protobufs.DataPeerListAnnounceType:
 				if err := e.handleDataPeerListAnnounce(
 					message.From,
 					msg.Address,
-					any,
+					a,
 				); err != nil {
 					e.logger.Debug("could not handle data peer list announce", zap.Error(err))
 				}

--- a/node/consensus/data/peer_messaging.go
+++ b/node/consensus/data/peer_messaging.go
@@ -186,6 +186,10 @@ func (e *DataClockConsensusEngine) handleMint(
 		return nil, errors.Wrap(errors.New("wrong destination"), "handle mint")
 	}
 
+	if err := t.Validate(); err != nil {
+		return nil, errors.Wrap(application.ErrInvalidStateTransition, "handle mint")
+	}
+
 	returnAddr := []byte{}
 	e.preMidnightMintMx.Lock()
 	if _, active := e.preMidnightMint[string(
@@ -211,17 +215,6 @@ func (e *DataClockConsensusEngine) handleMint(
 		return nil, errors.Wrap(errors.New("busy"), "handle mint")
 	}
 
-	if t == nil || t.Proofs == nil {
-		return nil, errors.Wrap(application.ErrInvalidStateTransition, "handle mint")
-	}
-
-	payload := []byte("mint")
-	for _, p := range t.Proofs {
-		payload = append(payload, p...)
-	}
-	if err := t.Signature.Verify(payload); err != nil {
-		return nil, errors.Wrap(application.ErrInvalidStateTransition, "handle mint")
-	}
 	pk, err := pcrypto.UnmarshalEd448PublicKey(
 		t.Signature.PublicKey.KeyValue,
 	)

--- a/node/execution/intrinsics/token/application/token_application.go
+++ b/node/execution/intrinsics/token/application/token_application.go
@@ -161,15 +161,12 @@ func (a *TokenApplication) ApplyTransitions(
 		i := i
 		switch t := transition.Request.(type) {
 		case *protobufs.TokenRequest_Mint:
-			if t == nil || t.Mint.Proofs == nil || t.Mint.Signature == nil {
+			if t == nil {
+				fails[i] = transition
 				continue
 			}
-
-			payload := []byte("mint")
-			for _, p := range t.Mint.Proofs {
-				payload = append(payload, p...)
-			}
-			if err := t.Mint.Signature.Verify(payload); err != nil {
+			if err := t.Mint.Validate(); err != nil {
+				fails[i] = transition
 				continue
 			}
 
@@ -177,6 +174,7 @@ func (a *TokenApplication) ApplyTransitions(
 				t.Mint.Signature.PublicKey.KeyValue,
 			)
 			if err != nil {
+				fails[i] = transition
 				continue
 			}
 

--- a/node/execution/intrinsics/token/application/token_handle_mint.go
+++ b/node/execution/intrinsics/token/application/token_handle_mint.go
@@ -31,7 +31,7 @@ func (a *TokenApplication) handleMint(
 	frame *protobufs.ClockFrame,
 	parallelismMap map[int]uint64,
 ) ([]*protobufs.TokenOutput, error) {
-	if t == nil || t.Proofs == nil || t.Signature == nil {
+	if err := t.Validate(); err != nil {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle mint")
 	}
 
@@ -39,9 +39,7 @@ func (a *TokenApplication) handleMint(
 	for _, p := range t.Proofs {
 		payload = append(payload, p...)
 	}
-	if err := t.Signature.Verify(payload); err != nil {
-		return nil, errors.Wrap(ErrInvalidStateTransition, "handle mint")
-	}
+
 	pk, err := pcrypto.UnmarshalEd448PublicKey(
 		t.Signature.PublicKey.KeyValue,
 	)

--- a/node/execution/intrinsics/token/application/token_handle_prover_announce.go
+++ b/node/execution/intrinsics/token/application/token_handle_prover_announce.go
@@ -13,36 +13,14 @@ func (a *TokenApplication) handleAnnounce(
 	[]*protobufs.TokenOutput,
 	error,
 ) {
-	var primary *protobufs.Ed448Signature
-	payload := []byte{}
-
-	if t == nil || t.PublicKeySignaturesEd448 == nil ||
-		len(t.PublicKeySignaturesEd448) == 0 {
+	if err := t.Validate(); err != nil {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle announce")
 	}
-	for i, p := range t.PublicKeySignaturesEd448 {
+
+	for _, p := range t.PublicKeySignaturesEd448 {
 		if _, touched := lockMap[string(p.PublicKey.KeyValue)]; touched {
 			return nil, errors.Wrap(ErrInvalidStateTransition, "handle announce")
 		}
-
-		if p.PublicKey == nil || p.Signature == nil ||
-			p.PublicKey.KeyValue == nil {
-			return nil, errors.Wrap(ErrInvalidStateTransition, "handle announce")
-		}
-		if i == 0 {
-			primary = p
-		} else {
-			payload = append(payload, p.PublicKey.KeyValue...)
-			if err := p.Verify(primary.PublicKey.KeyValue); err != nil {
-				return nil, errors.Wrap(ErrInvalidStateTransition, "handle announce")
-			}
-		}
-	}
-	if primary == nil {
-		return nil, errors.Wrap(ErrInvalidStateTransition, "handle announce")
-	}
-	if err := primary.Verify(payload); err != nil {
-		return nil, errors.Wrap(ErrInvalidStateTransition, "handle announce")
 	}
 
 	for _, p := range t.PublicKeySignaturesEd448[1:] {

--- a/node/execution/intrinsics/token/application/token_handle_prover_leave.go
+++ b/node/execution/intrinsics/token/application/token_handle_prover_leave.go
@@ -1,8 +1,6 @@
 package application
 
 import (
-	"encoding/binary"
-
 	"github.com/pkg/errors"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
 )
@@ -19,30 +17,17 @@ func (a *TokenApplication) handleDataAnnounceProverLeave(
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle leave")
 	}
 
-	payload := []byte("leave")
-
-	if t == nil || t.PublicKeySignatureEd448 == nil {
+	if err := t.Validate(); err != nil {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle leave")
 	}
 
-	if t.PublicKeySignatureEd448.PublicKey == nil ||
-		t.PublicKeySignatureEd448.Signature == nil ||
-		t.PublicKeySignatureEd448.PublicKey.KeyValue == nil ||
-		t.Filter == nil || len(t.Filter) != 32 ||
-		t.FrameNumber > currentFrameNumber {
+	if t.FrameNumber > currentFrameNumber {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle leave")
 	}
 
 	if _, touched := lockMap[string(
 		t.PublicKeySignatureEd448.PublicKey.KeyValue,
 	)]; touched {
-		return nil, errors.Wrap(ErrInvalidStateTransition, "handle leave")
-	}
-
-	payload = binary.BigEndian.AppendUint64(payload, t.FrameNumber)
-	payload = append(payload, t.Filter...)
-
-	if err := t.PublicKeySignatureEd448.Verify(payload); err != nil {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle leave")
 	}
 

--- a/node/execution/intrinsics/token/application/token_handle_prover_resume.go
+++ b/node/execution/intrinsics/token/application/token_handle_prover_resume.go
@@ -1,8 +1,6 @@
 package application
 
 import (
-	"encoding/binary"
-
 	"github.com/pkg/errors"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
 )
@@ -19,30 +17,17 @@ func (a *TokenApplication) handleDataAnnounceProverResume(
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle resume")
 	}
 
-	payload := []byte("resume")
-
-	if t == nil || t.PublicKeySignatureEd448 == nil {
+	if err := t.Validate(); err != nil {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle resume")
 	}
 
-	if t.PublicKeySignatureEd448.PublicKey == nil ||
-		t.PublicKeySignatureEd448.Signature == nil ||
-		t.PublicKeySignatureEd448.PublicKey.KeyValue == nil ||
-		t.Filter == nil || len(t.Filter) != 32 ||
-		t.FrameNumber > currentFrameNumber {
+	if t.FrameNumber > currentFrameNumber {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle resume")
 	}
 
 	if _, touched := lockMap[string(
 		t.PublicKeySignatureEd448.PublicKey.KeyValue,
 	)]; touched {
-		return nil, errors.Wrap(ErrInvalidStateTransition, "handle resume")
-	}
-
-	payload = binary.BigEndian.AppendUint64(payload, t.FrameNumber)
-	payload = append(payload, t.Filter...)
-
-	if err := t.PublicKeySignatureEd448.Verify(payload); err != nil {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle resume")
 	}
 

--- a/node/execution/intrinsics/token/application/token_handle_transfer.go
+++ b/node/execution/intrinsics/token/application/token_handle_transfer.go
@@ -16,12 +16,7 @@ func (a *TokenApplication) handleTransfer(
 	lockMap map[string]struct{},
 	t *protobufs.TransferCoinRequest,
 ) ([]*protobufs.TokenOutput, error) {
-	payload := []byte("transfer")
-	if t == nil || t.Signature == nil || t.OfCoin == nil ||
-		t.OfCoin.Address == nil || len(t.OfCoin.Address) != 32 ||
-		t.ToAccount == nil || t.ToAccount.GetImplicitAccount() == nil ||
-		t.ToAccount.GetImplicitAccount().Address == nil ||
-		len(t.ToAccount.GetImplicitAccount().Address) != 32 {
+	if err := t.Validate(); err != nil {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle transfer")
 	}
 
@@ -31,16 +26,6 @@ func (a *TokenApplication) handleTransfer(
 
 	coin, err := a.CoinStore.GetCoinByAddress(nil, t.OfCoin.Address)
 	if err != nil {
-		return nil, errors.Wrap(ErrInvalidStateTransition, "handle transfer")
-	}
-
-	payload = append(payload, t.OfCoin.Address...)
-	payload = append(
-		payload,
-		t.ToAccount.GetImplicitAccount().Address...,
-	)
-
-	if err := t.Signature.Verify(payload); err != nil {
 		return nil, errors.Wrap(ErrInvalidStateTransition, "handle transfer")
 	}
 

--- a/node/protobufs/keys.go
+++ b/node/protobufs/keys.go
@@ -182,6 +182,11 @@ func (s *Ed448Signature) Verify(msg []byte) error {
 		return errors.Wrap(errors.New("invalid length for signature"), "verify")
 	}
 
+	return s.verifyUnsafe(msg)
+}
+
+// verifyUnsafe is used to verify a signature without checking the length of the public key and signature.
+func (s *Ed448Signature) verifyUnsafe(msg []byte) error {
 	if !ed448.Verify(s.PublicKey.KeyValue, msg, s.Signature, "") {
 		return errors.Wrap(errors.New("invalid signature for public key"), "verify")
 	}

--- a/node/protobufs/node.go
+++ b/node/protobufs/node.go
@@ -2,6 +2,7 @@ package protobufs
 
 import (
 	"encoding/binary"
+	"time"
 
 	"github.com/iden3/go-iden3-crypto/poseidon"
 	pcrypto "github.com/libp2p/go-libp2p/core/crypto"
@@ -22,14 +23,6 @@ func (t *TokenRequest) Priority() uint64 {
 func (t *MintCoinRequest) RingAndParallelism(
 	ringCalc func(addr []byte) int,
 ) (int, uint32, error) {
-	payload := []byte("mint")
-	for _, p := range t.Proofs {
-		payload = append(payload, p...)
-	}
-	if err := t.Signature.Verify(payload); err != nil {
-		return -1, 0, errors.New("invalid")
-	}
-
 	pk, err := pcrypto.UnmarshalEd448PublicKey(
 		t.Signature.PublicKey.KeyValue,
 	)
@@ -57,4 +50,94 @@ func (t *MintCoinRequest) RingAndParallelism(
 	}
 
 	return -1, 0, errors.New("invalid")
+}
+
+// TokenRequest returns the TokenRequest for the TransferCoinRequest.
+func (t *TransferCoinRequest) TokenRequest() *TokenRequest {
+	return &TokenRequest{
+		Request: &TokenRequest_Transfer{
+			Transfer: t,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+}
+
+// TokenRequest returns the TokenRequest for the SplitCoinRequest.
+func (t *SplitCoinRequest) TokenRequest() *TokenRequest {
+	return &TokenRequest{
+		Request: &TokenRequest_Split{
+			Split: t,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+}
+
+// TokenRequest returns the TokenRequest for the MergeCoinRequest.
+func (t *MergeCoinRequest) TokenRequest() *TokenRequest {
+	return &TokenRequest{
+		Request: &TokenRequest_Merge{
+			Merge: t,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+}
+
+// TokenRequest returns the TokenRequest for the MintCoinRequest.
+func (t *MintCoinRequest) TokenRequest() *TokenRequest {
+	return &TokenRequest{
+		Request: &TokenRequest_Mint{
+			Mint: t,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+}
+
+// TokenRequest returns the TokenRequest for the AnnounceProverRequest.
+func (t *AnnounceProverRequest) TokenRequest() *TokenRequest {
+	return &TokenRequest{
+		Request: &TokenRequest_Announce{
+			Announce: t,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+}
+
+// TokenRequest returns the TokenRequest for the AnnounceProverJoin.
+func (t *AnnounceProverJoin) TokenRequest() *TokenRequest {
+	return &TokenRequest{
+		Request: &TokenRequest_Join{
+			Join: t,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+}
+
+// TokenRequest returns the TokenRequest for the AnnounceProverLeave.
+func (t *AnnounceProverLeave) TokenRequest() *TokenRequest {
+	return &TokenRequest{
+		Request: &TokenRequest_Leave{
+			Leave: t,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+}
+
+// TokenRequest returns the TokenRequest for the AnnounceProverPause.
+func (t *AnnounceProverPause) TokenRequest() *TokenRequest {
+	return &TokenRequest{
+		Request: &TokenRequest_Pause{
+			Pause: t,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
+}
+
+// TokenRequest returns the TokenRequest for the AnnounceProverResume.
+func (t *AnnounceProverResume) TokenRequest() *TokenRequest {
+	return &TokenRequest{
+		Request: &TokenRequest_Resume{
+			Resume: t,
+		},
+		Timestamp: time.Now().UnixMilli(),
+	}
 }

--- a/node/protobufs/validation.go
+++ b/node/protobufs/validation.go
@@ -1,0 +1,700 @@
+package protobufs
+
+import (
+	"encoding/binary"
+
+	"github.com/pkg/errors"
+)
+
+type signatureMessage interface {
+	signatureMessage() []byte
+}
+
+var _ signatureMessage = (*TransferCoinRequest)(nil)
+
+func (t *TransferCoinRequest) signatureMessage() []byte {
+	payload := []byte("transfer")
+	payload = append(payload, t.OfCoin.Address...)
+	payload = append(
+		payload,
+		t.ToAccount.GetImplicitAccount().Address...,
+	)
+	return payload
+}
+
+var _ signatureMessage = (*SplitCoinRequest)(nil)
+
+func (t *SplitCoinRequest) signatureMessage() []byte {
+	payload := []byte("split")
+	payload = append(payload, t.OfCoin.Address...)
+	for _, a := range t.Amounts {
+		payload = append(payload, a...)
+	}
+	return payload
+}
+
+var _ signatureMessage = (*MergeCoinRequest)(nil)
+
+func (t *MergeCoinRequest) signatureMessage() []byte {
+	payload := []byte("merge")
+	for _, c := range t.Coins {
+		payload = append(payload, c.Address...)
+	}
+	return payload
+}
+
+var _ signatureMessage = (*MintCoinRequest)(nil)
+
+func (t *MintCoinRequest) signatureMessage() []byte {
+	payload := []byte("mint")
+	for _, p := range t.Proofs {
+		payload = append(payload, p...)
+	}
+	return payload
+}
+
+// NOTE: AnnounceProverRequest has a non-trivial signature payload.
+
+var _ signatureMessage = (*AnnounceProverJoin)(nil)
+
+func (t *AnnounceProverJoin) signatureMessage() []byte {
+	payload := []byte("join")
+	payload = binary.BigEndian.AppendUint64(payload, t.FrameNumber)
+	payload = append(payload, t.Filter...)
+	return payload
+}
+
+var _ signatureMessage = (*AnnounceProverLeave)(nil)
+
+func (t *AnnounceProverLeave) signatureMessage() []byte {
+	payload := []byte("leave")
+	payload = binary.BigEndian.AppendUint64(payload, t.FrameNumber)
+	payload = append(payload, t.Filter...)
+	return payload
+}
+
+var _ signatureMessage = (*AnnounceProverPause)(nil)
+
+func (t *AnnounceProverPause) signatureMessage() []byte {
+	payload := []byte("pause")
+	payload = binary.BigEndian.AppendUint64(payload, t.FrameNumber)
+	payload = append(payload, t.Filter...)
+	return payload
+}
+
+var _ signatureMessage = (*AnnounceProverResume)(nil)
+
+func (t *AnnounceProverResume) signatureMessage() []byte {
+	payload := []byte("resume")
+	payload = binary.BigEndian.AppendUint64(payload, t.FrameNumber)
+	payload = append(payload, t.Filter...)
+	return payload
+}
+
+// SignedMessage is a message that has a signature.
+type SignedMessage interface {
+	// ValidateSignature checks the signature of the message.
+	// The message contents are expected to be valid - validation
+	// of contents must precede validation of the signature.
+	ValidateSignature() error
+}
+
+var _ SignedMessage = (*TransferCoinRequest)(nil)
+
+// ValidateSignature checks the signature of the transfer coin request.
+func (t *TransferCoinRequest) ValidateSignature() error {
+	if err := t.Signature.verifyUnsafe(t.signatureMessage()); err != nil {
+		return errors.Wrap(err, "validate signature")
+	}
+	return nil
+}
+
+var _ SignedMessage = (*SplitCoinRequest)(nil)
+
+// ValidateSignature checks the signature of the split coin request.
+func (t *SplitCoinRequest) ValidateSignature() error {
+	if err := t.Signature.verifyUnsafe(t.signatureMessage()); err != nil {
+		return errors.Wrap(err, "validate signature")
+	}
+	return nil
+}
+
+var _ SignedMessage = (*MergeCoinRequest)(nil)
+
+// ValidateSignature checks the signature of the merge coin request.
+func (t *MergeCoinRequest) ValidateSignature() error {
+	if err := t.Signature.verifyUnsafe(t.signatureMessage()); err != nil {
+		return errors.Wrap(err, "validate signature")
+	}
+	return nil
+}
+
+var _ SignedMessage = (*MintCoinRequest)(nil)
+
+// ValidateSignature checks the signature of the mint coin request.
+func (t *MintCoinRequest) ValidateSignature() error {
+	if err := t.Signature.verifyUnsafe(t.signatureMessage()); err != nil {
+		return errors.Wrap(err, "validate signature")
+	}
+	return nil
+}
+
+var _ SignedMessage = (*AnnounceProverRequest)(nil)
+
+// ValidateSignature checks the signature of the announce prover request.
+func (t *AnnounceProverRequest) ValidateSignature() error {
+	payload := []byte{}
+	primary := t.PublicKeySignaturesEd448[0]
+	for _, p := range t.PublicKeySignaturesEd448[1:] {
+		payload = append(payload, p.PublicKey.KeyValue...)
+		if err := p.verifyUnsafe(primary.PublicKey.KeyValue); err != nil {
+			return errors.Wrap(err, "validate signature")
+		}
+	}
+	if err := primary.verifyUnsafe(payload); err != nil {
+		return errors.Wrap(err, "validate signature")
+	}
+	return nil
+}
+
+var _ SignedMessage = (*AnnounceProverJoin)(nil)
+
+// ValidateSignature checks the signature of the announce prover join.
+func (t *AnnounceProverJoin) ValidateSignature() error {
+	if err := t.PublicKeySignatureEd448.verifyUnsafe(t.signatureMessage()); err != nil {
+		return errors.Wrap(err, "validate signature")
+	}
+	return nil
+}
+
+var _ SignedMessage = (*AnnounceProverLeave)(nil)
+
+// ValidateSignature checks the signature of the announce prover leave.
+func (t *AnnounceProverLeave) ValidateSignature() error {
+	if err := t.PublicKeySignatureEd448.verifyUnsafe(t.signatureMessage()); err != nil {
+		return errors.Wrap(err, "validate signature")
+	}
+	return nil
+}
+
+var _ SignedMessage = (*AnnounceProverPause)(nil)
+
+// ValidateSignature checks the signature of the announce prover pause.
+func (t *AnnounceProverPause) ValidateSignature() error {
+	if err := t.PublicKeySignatureEd448.verifyUnsafe(t.signatureMessage()); err != nil {
+		return errors.Wrap(err, "validate signature")
+	}
+	return nil
+}
+
+var _ SignedMessage = (*AnnounceProverResume)(nil)
+
+// ValidateSignature checks the signature of the announce prover resume.
+func (t *AnnounceProverResume) ValidateSignature() error {
+	if err := t.PublicKeySignatureEd448.verifyUnsafe(t.signatureMessage()); err != nil {
+		return errors.Wrap(err, "validate signature")
+	}
+	return nil
+}
+
+// ValidatableMessage is a message that can be validated.
+type ValidatableMessage interface {
+	// Validate checks the message contents.
+	// It will also verify signatures if the message is signed.
+	Validate() error
+}
+
+var _ ValidatableMessage = (*Ed448PublicKey)(nil)
+
+// Validate checks the Ed448 public key.
+func (e *Ed448PublicKey) Validate() error {
+	if e == nil {
+		return errors.New("nil Ed448 public key")
+	}
+	if len(e.KeyValue) != 57 {
+		return errors.New("invalid Ed448 public key")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*Ed448Signature)(nil)
+
+// Validate checks the Ed448 signature.
+func (e *Ed448Signature) Validate() error {
+	if e == nil {
+		return errors.New("nil Ed448 signature")
+	}
+	if err := e.PublicKey.Validate(); err != nil {
+		return errors.Wrap(err, "public key")
+	}
+	if len(e.Signature) != 114 {
+		return errors.New("invalid Ed448 signature")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*ImplicitAccount)(nil)
+
+// Validate checks the implicit account.
+func (i *ImplicitAccount) Validate() error {
+	if i == nil {
+		return errors.New("nil implicit account")
+	}
+	// TODO: Validate ImplicitType.
+	if len(i.Address) != 32 {
+		return errors.New("invalid implicit account")
+	}
+	// TODO: Validate Domain.
+	return nil
+}
+
+var _ ValidatableMessage = (*OriginatedAccountRef)(nil)
+
+// Validate checks the originated account.
+func (o *OriginatedAccountRef) Validate() error {
+	if o == nil {
+		return errors.New("nil originated account")
+	}
+	if len(o.Address) != 32 {
+		return errors.New("invalid originated account")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*AccountRef)(nil)
+
+// Validate checks the account reference.
+func (a *AccountRef) Validate() error {
+	if a == nil {
+		return errors.New("nil account reference")
+	}
+	switch {
+	case a.GetImplicitAccount() != nil:
+		if err := a.GetImplicitAccount().Validate(); err != nil {
+			return errors.Wrap(err, "implicit account")
+		}
+	case a.GetOriginatedAccount() != nil:
+		if err := a.GetOriginatedAccount().Validate(); err != nil {
+			return errors.Wrap(err, "originated account")
+		}
+	default:
+		return errors.New("invalid account reference")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*CoinRef)(nil)
+
+// Validate checks the coin reference.
+func (c *CoinRef) Validate() error {
+	if c == nil {
+		return errors.New("nil coin reference")
+	}
+	if len(c.Address) != 32 {
+		return errors.New("invalid coin reference")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*AccountAllowanceRef)(nil)
+
+// Validate checks the account allowance reference.
+func (a *AccountAllowanceRef) Validate() error {
+	if a == nil {
+		return errors.New("nil account allowance reference")
+	}
+	if len(a.Address) != 32 {
+		return errors.New("invalid account allowance reference")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*CoinAllowanceRef)(nil)
+
+// Validate checks the coin allowance reference.
+func (c *CoinAllowanceRef) Validate() error {
+	if c == nil {
+		return errors.New("nil coin allowance reference")
+	}
+	if len(c.Address) != 32 {
+		return errors.New("invalid coin allowance reference")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*TokenRequest)(nil)
+
+// Validate checks the token request.
+func (t *TokenRequest) Validate() error {
+	if t == nil {
+		return errors.New("nil token request")
+	}
+	switch {
+	case t.GetTransfer() != nil:
+		return t.GetTransfer().Validate()
+	case t.GetSplit() != nil:
+		return t.GetSplit().Validate()
+	case t.GetMerge() != nil:
+		return t.GetMerge().Validate()
+	case t.GetMint() != nil:
+		return t.GetMint().Validate()
+	case t.GetAnnounce() != nil:
+		return t.GetAnnounce().Validate()
+	case t.GetJoin() != nil:
+		return t.GetJoin().Validate()
+	case t.GetLeave() != nil:
+		return t.GetLeave().Validate()
+	case t.GetPause() != nil:
+		return t.GetPause().Validate()
+	case t.GetResume() != nil:
+		return t.GetResume().Validate()
+	default:
+		return nil
+	}
+}
+
+var _ ValidatableMessage = (*TransferCoinRequest)(nil)
+
+// Validate checks the transfer coin request.
+func (t *TransferCoinRequest) Validate() error {
+	if t == nil {
+		return errors.New("nil transfer coin request")
+	}
+	if err := t.ToAccount.Validate(); err != nil {
+		return errors.Wrap(err, "to account")
+	}
+	// TODO: Validate RefundAccount.
+	if err := t.OfCoin.Validate(); err != nil {
+		return errors.Wrap(err, "of coin")
+	}
+	// TODO: Validate Expiry.
+	// TODO: Validate AccountAllowance.
+	// TODO: Validate CoinAllowance.
+	if err := t.Signature.Validate(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	if err := t.ValidateSignature(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*SplitCoinRequest)(nil)
+
+// Validate checks the split coin request.
+func (t *SplitCoinRequest) Validate() error {
+	if t == nil {
+		return errors.New("nil split coin request")
+	}
+	if err := t.OfCoin.Validate(); err != nil {
+		return errors.Wrap(err, "of coin")
+	}
+	if n := len(t.Amounts); n == 0 || n > 100 {
+		return errors.New("invalid amounts")
+	}
+	for _, a := range t.Amounts {
+		if n := len(a); n == 0 || n > 32 {
+			return errors.New("invalid amount")
+		}
+	}
+	// TODO: Validate AccountAllowance.
+	// TODO: Validate CoinAllowance.
+	if err := t.Signature.Validate(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	if err := t.ValidateSignature(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*MergeCoinRequest)(nil)
+
+// Validate checks the merge coin request.
+func (t *MergeCoinRequest) Validate() error {
+	if t == nil {
+		return errors.New("nil merge coin request")
+	}
+	if len(t.Coins) == 0 {
+		return errors.New("invalid coins")
+	}
+	for _, c := range t.Coins {
+		if err := c.Validate(); err != nil {
+			return errors.Wrap(err, "coin")
+		}
+	}
+	// TODO: Validate AccountAllowance.
+	// TODO: Validate CoinAllowance.
+	if err := t.Signature.Validate(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	if err := t.ValidateSignature(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*MintCoinRequest)(nil)
+
+// Validate checks the mint coin request.
+func (t *MintCoinRequest) Validate() error {
+	if t == nil {
+		return errors.New("nil mint coin request")
+	}
+	if len(t.Proofs) == 0 {
+		return errors.New("invalid proofs")
+	}
+	// TODO: Validate AccountAllowance.
+	if err := t.Signature.Validate(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	if err := t.ValidateSignature(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*AnnounceProverRequest)(nil)
+
+// Validate checks the announce prover request.
+func (t *AnnounceProverRequest) Validate() error {
+	if t == nil {
+		return errors.New("nil announce prover request")
+	}
+	if len(t.PublicKeySignaturesEd448) == 0 {
+		return errors.New("invalid public key signatures")
+	}
+	for _, p := range t.PublicKeySignaturesEd448 {
+		if err := p.Validate(); err != nil {
+			return errors.Wrap(err, "public key signature")
+		}
+	}
+	if err := t.ValidateSignature(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*AnnounceProverJoin)(nil)
+
+// Validate checks the announce prover join.
+func (t *AnnounceProverJoin) Validate() error {
+	if t == nil {
+		return errors.New("nil announce prover join")
+	}
+	if len(t.Filter) != 32 {
+		return errors.New("invalid filter")
+	}
+	if announce := t.Announce; announce != nil {
+		if err := announce.Validate(); err != nil {
+			return errors.Wrap(err, "announce")
+		}
+	}
+	if err := t.PublicKeySignatureEd448.Validate(); err != nil {
+		return errors.Wrap(err, "public key signature")
+	}
+	if err := t.ValidateSignature(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*AnnounceProverLeave)(nil)
+
+// Validate checks the announce prover leave.
+func (t *AnnounceProverLeave) Validate() error {
+	if t == nil {
+		return errors.New("nil announce prover leave")
+	}
+	if len(t.Filter) != 32 {
+		return errors.New("invalid filter")
+	}
+	if err := t.PublicKeySignatureEd448.Validate(); err != nil {
+		return errors.Wrap(err, "public key signature")
+	}
+	if err := t.ValidateSignature(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*AnnounceProverPause)(nil)
+
+// Validate checks the announce prover pause.
+func (t *AnnounceProverPause) Validate() error {
+	if t == nil {
+		return errors.New("nil announce prover pause")
+	}
+	if len(t.Filter) != 32 {
+		return errors.New("invalid filter")
+	}
+	if err := t.PublicKeySignatureEd448.Validate(); err != nil {
+		return errors.Wrap(err, "public key signature")
+	}
+	if err := t.ValidateSignature(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	return nil
+}
+
+var _ ValidatableMessage = (*AnnounceProverResume)(nil)
+
+// Validate checks the announce prover resume.
+func (t *AnnounceProverResume) Validate() error {
+	if t == nil {
+		return errors.New("nil announce prover resume")
+	}
+	if len(t.Filter) != 32 {
+		return errors.New("invalid filter")
+	}
+	if err := t.PublicKeySignatureEd448.Validate(); err != nil {
+		return errors.Wrap(err, "public key signature")
+	}
+	if err := t.ValidateSignature(); err != nil {
+		return errors.Wrap(err, "signature")
+	}
+	return nil
+}
+
+// SignableED448Message is a message that can be signed.
+type SignableED448Message interface {
+	// SignED448 signs the message with the given key, modifying the message.
+	// The message contents are expected to be valid - message
+	// contents must be validated, or correctly constructed, before signing.
+	SignED448(publicKey []byte, sign func([]byte) ([]byte, error)) error
+}
+
+func newED448Signature(publicKey, signature []byte) *Ed448Signature {
+	return &Ed448Signature{
+		PublicKey: &Ed448PublicKey{
+			KeyValue: publicKey,
+		},
+		Signature: signature,
+	}
+}
+
+var _ SignableED448Message = (*TransferCoinRequest)(nil)
+
+// SignED448 signs the transfer coin request with the given key.
+func (t *TransferCoinRequest) SignED448(publicKey []byte, sign func([]byte) ([]byte, error)) error {
+	signature, err := sign(t.signatureMessage())
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	t.Signature = newED448Signature(publicKey, signature)
+	return nil
+}
+
+var _ SignableED448Message = (*SplitCoinRequest)(nil)
+
+// SignED448 signs the split coin request with the given key.
+func (t *SplitCoinRequest) SignED448(publicKey []byte, sign func([]byte) ([]byte, error)) error {
+	signature, err := sign(t.signatureMessage())
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	t.Signature = newED448Signature(publicKey, signature)
+	return nil
+}
+
+var _ SignableED448Message = (*MergeCoinRequest)(nil)
+
+// SignED448 signs the merge coin request with the given key.
+func (t *MergeCoinRequest) SignED448(publicKey []byte, sign func([]byte) ([]byte, error)) error {
+	signature, err := sign(t.signatureMessage())
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	t.Signature = newED448Signature(publicKey, signature)
+	return nil
+}
+
+var _ SignableED448Message = (*MintCoinRequest)(nil)
+
+// SignED448 signs the mint coin request with the given key.
+func (t *MintCoinRequest) SignED448(publicKey []byte, sign func([]byte) ([]byte, error)) error {
+	signature, err := sign(t.signatureMessage())
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	t.Signature = newED448Signature(publicKey, signature)
+	return nil
+}
+
+type ED448SignHelper struct {
+	PublicKey []byte
+	Sign      func([]byte) ([]byte, error)
+}
+
+// SignED448 signs the announce prover request with the given keys.
+func (t *AnnounceProverRequest) SignED448(helpers []ED448SignHelper) error {
+	if len(helpers) == 0 {
+		return errors.New("no keys")
+	}
+	payload := []byte{}
+	primary := helpers[0]
+	signatures := make([]*Ed448Signature, len(helpers))
+	for i, k := range helpers[1:] {
+		payload = append(payload, k.PublicKey...)
+		signature, err := k.Sign(primary.PublicKey)
+		if err != nil {
+			return errors.Wrap(err, "sign")
+		}
+		signatures[i+1] = newED448Signature(k.PublicKey, signature)
+	}
+	signature, err := primary.Sign(payload)
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	signatures[0] = newED448Signature(primary.PublicKey, signature)
+	t.PublicKeySignaturesEd448 = signatures
+	return nil
+}
+
+var _ SignableED448Message = (*AnnounceProverJoin)(nil)
+
+// SignED448 signs the announce prover join with the given key.
+func (t *AnnounceProverJoin) SignED448(publicKey []byte, sign func([]byte) ([]byte, error)) error {
+	signature, err := sign(t.signatureMessage())
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	t.PublicKeySignatureEd448 = newED448Signature(publicKey, signature)
+	return nil
+}
+
+var _ SignableED448Message = (*AnnounceProverLeave)(nil)
+
+// SignED448 signs the announce prover leave with the given key.
+func (t *AnnounceProverLeave) SignED448(publicKey []byte, sign func([]byte) ([]byte, error)) error {
+	signature, err := sign(t.signatureMessage())
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	t.PublicKeySignatureEd448 = newED448Signature(publicKey, signature)
+	return nil
+}
+
+var _ SignableED448Message = (*AnnounceProverPause)(nil)
+
+// SignED448 signs the announce prover pause with the given key.
+func (t *AnnounceProverPause) SignED448(publicKey []byte, sign func([]byte) ([]byte, error)) error {
+	signature, err := sign(t.signatureMessage())
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	t.PublicKeySignatureEd448 = newED448Signature(publicKey, signature)
+	return nil
+}
+
+var _ SignableED448Message = (*AnnounceProverResume)(nil)
+
+// SignED448 signs the announce prover resume with the given key.
+func (t *AnnounceProverResume) SignED448(publicKey []byte, sign func([]byte) ([]byte, error)) error {
+	signature, err := sign(t.signatureMessage())
+	if err != nil {
+		return errors.Wrap(err, "sign")
+	}
+	t.PublicKeySignatureEd448 = newED448Signature(publicKey, signature)
+	return nil
+}

--- a/node/protobufs/validation_internal_test.go
+++ b/node/protobufs/validation_internal_test.go
@@ -1,0 +1,5 @@
+package protobufs
+
+func SignatureMessageOf(m any) []byte {
+	return m.(signatureMessage).signatureMessage()
+}

--- a/node/protobufs/validation_test.go
+++ b/node/protobufs/validation_test.go
@@ -1,0 +1,914 @@
+package protobufs_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
+)
+
+func newPrivateKey() crypto.PrivKey {
+	privKey, _, err := crypto.GenerateEd448Key(rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	return privKey
+}
+
+func publicKeyBytesOf(privKey crypto.PrivKey) []byte {
+	b, err := privKey.GetPublic().Raw()
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+var (
+	primaryPrivateKey     crypto.PrivKey = newPrivateKey()
+	primaryPublicKeyBytes []byte         = publicKeyBytesOf(primaryPrivateKey)
+
+	secondaryPrivateKey     crypto.PrivKey = newPrivateKey()
+	secondaryPublicKeyBytes []byte         = publicKeyBytesOf(secondaryPrivateKey)
+)
+
+func metaAppend[T any](bs ...[]T) []T {
+	var result []T
+	for _, b := range bs {
+		result = append(result, b...)
+	}
+	return result
+}
+
+func TestTransferCoinRequestSignatureRoundtrip(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.TransferCoinRequest{
+		OfCoin: &protobufs.CoinRef{
+			Address: bytes.Repeat([]byte{0x01}, 32),
+		},
+		ToAccount: &protobufs.AccountRef{
+			Account: &protobufs.AccountRef_ImplicitAccount{
+				ImplicitAccount: &protobufs.ImplicitAccount{
+					Address: bytes.Repeat([]byte{0x02}, 32),
+				},
+			},
+		},
+		Signature: &protobufs.Ed448Signature{
+			Signature: bytes.Repeat([]byte{0x03}, 114),
+			PublicKey: &protobufs.Ed448PublicKey{
+				KeyValue: bytes.Repeat([]byte{0x04}, 57),
+			},
+		},
+	}
+	if !bytes.Equal(
+		protobufs.SignatureMessageOf(message),
+		metaAppend(
+			[]byte("transfer"),
+			bytes.Repeat([]byte{0x01}, 32),
+			bytes.Repeat([]byte{0x02}, 32),
+		),
+	) {
+		t.Fatal("unexpected signature message")
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.Signature.PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSplitCoinRequestSignatureRoundtrip(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.SplitCoinRequest{
+		OfCoin: &protobufs.CoinRef{
+			Address: bytes.Repeat([]byte{0x01}, 32),
+		},
+		Amounts: [][]byte{
+			bytes.Repeat([]byte{0x02}, 32),
+			bytes.Repeat([]byte{0x03}, 32),
+		},
+		Signature: &protobufs.Ed448Signature{
+			Signature: bytes.Repeat([]byte{0x04}, 114),
+			PublicKey: &protobufs.Ed448PublicKey{
+				KeyValue: bytes.Repeat([]byte{0x05}, 57),
+			},
+		},
+	}
+	if !bytes.Equal(
+		protobufs.SignatureMessageOf(message),
+		metaAppend(
+			[]byte("split"),
+			bytes.Repeat([]byte{0x01}, 32),
+			bytes.Repeat([]byte{0x02}, 32),
+			bytes.Repeat([]byte{0x03}, 32),
+		),
+	) {
+		t.Fatal("unexpected signature message")
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.Signature.PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMergeCoinRequestSignatureRoundtrip(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.MergeCoinRequest{
+		Coins: []*protobufs.CoinRef{
+			{
+				Address: bytes.Repeat([]byte{0x01}, 32),
+			},
+			{
+				Address: bytes.Repeat([]byte{0x02}, 32),
+			},
+		},
+		Signature: &protobufs.Ed448Signature{
+			Signature: bytes.Repeat([]byte{0x03}, 114),
+			PublicKey: &protobufs.Ed448PublicKey{
+				KeyValue: bytes.Repeat([]byte{0x04}, 57),
+			},
+		},
+	}
+	if !bytes.Equal(
+		protobufs.SignatureMessageOf(message),
+		metaAppend(
+			[]byte("merge"),
+			bytes.Repeat([]byte{0x01}, 32),
+			bytes.Repeat([]byte{0x02}, 32),
+		),
+	) {
+		t.Fatal("unexpected signature message")
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.Signature.PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMintCoinRequestSignatureRoundtrip(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.MintCoinRequest{
+		Proofs: [][]byte{
+			bytes.Repeat([]byte{0x01}, 32),
+			bytes.Repeat([]byte{0x02}, 32),
+		},
+		Signature: &protobufs.Ed448Signature{
+			Signature: bytes.Repeat([]byte{0x03}, 114),
+			PublicKey: &protobufs.Ed448PublicKey{
+				KeyValue: bytes.Repeat([]byte{0x04}, 57),
+			},
+		},
+	}
+	if !bytes.Equal(
+		protobufs.SignatureMessageOf(message),
+		metaAppend(
+			[]byte("mint"),
+			bytes.Repeat([]byte{0x01}, 32),
+			bytes.Repeat([]byte{0x02}, 32),
+		),
+	) {
+		t.Fatal("unexpected signature message")
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.Signature.PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnounceProverRequestSignatureRoundtrip(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.AnnounceProverRequest{
+		PublicKeySignaturesEd448: []*protobufs.Ed448Signature{
+			{
+				Signature: bytes.Repeat([]byte{0x01}, 114),
+				PublicKey: &protobufs.Ed448PublicKey{
+					KeyValue: bytes.Repeat([]byte{0x02}, 57),
+				},
+			},
+			{
+				Signature: bytes.Repeat([]byte{0x03}, 114),
+				PublicKey: &protobufs.Ed448PublicKey{
+					KeyValue: bytes.Repeat([]byte{0x04}, 57),
+				},
+			},
+		},
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448([]protobufs.ED448SignHelper{
+		{
+			PublicKey: primaryPublicKeyBytes,
+			Sign:      primaryPrivateKey.Sign,
+		},
+		{
+			PublicKey: secondaryPublicKeyBytes,
+			Sign:      secondaryPrivateKey.Sign,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.PublicKeySignaturesEd448[0].PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if !bytes.Equal(message.PublicKeySignaturesEd448[1].PublicKey.KeyValue, secondaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+	message = &protobufs.AnnounceProverRequest{
+		PublicKeySignaturesEd448: []*protobufs.Ed448Signature{
+			{
+				Signature: bytes.Repeat([]byte{0x01}, 114),
+				PublicKey: &protobufs.Ed448PublicKey{
+					KeyValue: bytes.Repeat([]byte{0x02}, 57),
+				},
+			},
+		},
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448([]protobufs.ED448SignHelper{
+		{
+			PublicKey: primaryPublicKeyBytes,
+			Sign:      primaryPrivateKey.Sign,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.PublicKeySignaturesEd448[0].PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnounceProverJoinSignatureRoundtrip(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.AnnounceProverJoin{
+		Filter:      bytes.Repeat([]byte{0x01}, 32),
+		FrameNumber: 1,
+		PublicKeySignatureEd448: &protobufs.Ed448Signature{
+			Signature: bytes.Repeat([]byte{0x02}, 114),
+			PublicKey: &protobufs.Ed448PublicKey{
+				KeyValue: bytes.Repeat([]byte{0x03}, 57),
+			},
+		},
+	}
+	if !bytes.Equal(
+		protobufs.SignatureMessageOf(message),
+		metaAppend(
+			[]byte("join"),
+			[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			bytes.Repeat([]byte{0x01}, 32),
+		),
+	) {
+		t.Fatal("unexpected signature message")
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.PublicKeySignatureEd448.PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnounceProverLeaveSignatureRoundtrip(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.AnnounceProverLeave{
+		Filter:      bytes.Repeat([]byte{0x01}, 32),
+		FrameNumber: 1,
+		PublicKeySignatureEd448: &protobufs.Ed448Signature{
+			Signature: bytes.Repeat([]byte{0x02}, 114),
+			PublicKey: &protobufs.Ed448PublicKey{
+				KeyValue: bytes.Repeat([]byte{0x03}, 57),
+			},
+		},
+	}
+	if !bytes.Equal(
+		protobufs.SignatureMessageOf(message),
+		metaAppend(
+			[]byte("leave"),
+			[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			bytes.Repeat([]byte{0x01}, 32),
+		),
+	) {
+		t.Fatal("unexpected signature message")
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.PublicKeySignatureEd448.PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnounceProverPauseSignatureRoundtrip(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.AnnounceProverPause{
+		Filter:      bytes.Repeat([]byte{0x01}, 32),
+		FrameNumber: 1,
+		PublicKeySignatureEd448: &protobufs.Ed448Signature{
+			Signature: bytes.Repeat([]byte{0x02}, 114),
+			PublicKey: &protobufs.Ed448PublicKey{
+				KeyValue: bytes.Repeat([]byte{0x03}, 57),
+			},
+		},
+	}
+	if !bytes.Equal(
+		protobufs.SignatureMessageOf(message),
+		metaAppend(
+			[]byte("pause"),
+			[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			bytes.Repeat([]byte{0x01}, 32),
+		),
+	) {
+		t.Fatal("unexpected signature message")
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.PublicKeySignatureEd448.PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnounceProverResumeSignatureRoundtrip(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.AnnounceProverResume{
+		Filter:      bytes.Repeat([]byte{0x01}, 32),
+		FrameNumber: 1,
+		PublicKeySignatureEd448: &protobufs.Ed448Signature{
+			Signature: bytes.Repeat([]byte{0x02}, 114),
+			PublicKey: &protobufs.Ed448PublicKey{
+				KeyValue: bytes.Repeat([]byte{0x03}, 57),
+			},
+		},
+	}
+	if !bytes.Equal(
+		protobufs.SignatureMessageOf(message),
+		metaAppend(
+			[]byte("resume"),
+			[]byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01},
+			bytes.Repeat([]byte{0x01}, 32),
+		),
+	) {
+		t.Fatal("unexpected signature message")
+	}
+	if err := message.ValidateSignature(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(message.PublicKeySignatureEd448.PublicKey.KeyValue, primaryPublicKeyBytes) {
+		t.Fatal("unexpected public key")
+	}
+	if err := message.ValidateSignature(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEd448PublicKeyValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.Ed448PublicKey)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.Ed448PublicKey{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.KeyValue = bytes.Repeat([]byte{0x01}, 57)
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestEd448SignatureValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.Ed448Signature)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.Ed448Signature{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Signature = bytes.Repeat([]byte{0x01}, 114)
+	message.PublicKey = &protobufs.Ed448PublicKey{
+		KeyValue: bytes.Repeat([]byte{0x02}, 57),
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestImplicitAccountValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.ImplicitAccount)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.ImplicitAccount{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Address = bytes.Repeat([]byte{0x01}, 32)
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestOriginatedAccountRefValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.OriginatedAccountRef)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.OriginatedAccountRef{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Address = bytes.Repeat([]byte{0x01}, 32)
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAccountRefValidate(t *testing.T) {
+	t.Parallel()
+	message := &protobufs.AccountRef{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Account = &protobufs.AccountRef_ImplicitAccount{
+		ImplicitAccount: &protobufs.ImplicitAccount{
+			Address: bytes.Repeat([]byte{0x01}, 32),
+		},
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	message.Account = &protobufs.AccountRef_OriginatedAccount{
+		OriginatedAccount: &protobufs.OriginatedAccountRef{
+			Address: bytes.Repeat([]byte{0x02}, 32),
+		},
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCoinRefValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.CoinRef)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.CoinRef{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Address = bytes.Repeat([]byte{0x01}, 32)
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAccountAllowanceRefValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.AccountAllowanceRef)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.AccountAllowanceRef{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Address = bytes.Repeat([]byte{0x01}, 32)
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCoinAllowanceRefValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.CoinAllowanceRef)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.CoinAllowanceRef{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Address = bytes.Repeat([]byte{0x01}, 32)
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTransferCoinRequestValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.TransferCoinRequest)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.TransferCoinRequest{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Transfer{
+			Transfer: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.OfCoin = &protobufs.CoinRef{
+		Address: bytes.Repeat([]byte{0x01}, 32),
+	}
+	message.ToAccount = &protobufs.AccountRef{
+		Account: &protobufs.AccountRef_ImplicitAccount{
+			ImplicitAccount: &protobufs.ImplicitAccount{
+				Address: bytes.Repeat([]byte{0x02}, 32),
+			},
+		},
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Transfer{
+			Transfer: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSplitCoinRequestValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.SplitCoinRequest)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.SplitCoinRequest{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Split{
+			Split: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.OfCoin = &protobufs.CoinRef{
+		Address: bytes.Repeat([]byte{0x01}, 32),
+	}
+	message.Amounts = [][]byte{
+		bytes.Repeat([]byte{0x02}, 32),
+		bytes.Repeat([]byte{0x03}, 32),
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Split{
+			Split: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMergeCoinRequestValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.MergeCoinRequest)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.MergeCoinRequest{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Merge{
+			Merge: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Coins = []*protobufs.CoinRef{
+		{
+			Address: bytes.Repeat([]byte{0x01}, 32),
+		},
+		{
+			Address: bytes.Repeat([]byte{0x02}, 32),
+		},
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Merge{
+			Merge: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMintCoinRequestValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.MintCoinRequest)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.MintCoinRequest{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Mint{
+			Mint: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Proofs = [][]byte{
+		bytes.Repeat([]byte{0x01}, 32),
+		bytes.Repeat([]byte{0x02}, 32),
+	}
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Mint{
+			Mint: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnounceProverRequestValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.AnnounceProverRequest)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.AnnounceProverRequest{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Announce{
+			Announce: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := message.SignED448([]protobufs.ED448SignHelper{
+		{
+			PublicKey: primaryPublicKeyBytes,
+			Sign:      primaryPrivateKey.Sign,
+		},
+		{
+			PublicKey: secondaryPublicKeyBytes,
+			Sign:      secondaryPrivateKey.Sign,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Announce{
+			Announce: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestAnnounceProverJoinValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.AnnounceProverJoin)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.AnnounceProverJoin{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Join{
+			Join: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Filter = bytes.Repeat([]byte{0x01}, 32)
+	message.FrameNumber = 1
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Join{
+			Join: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+	announce := &protobufs.AnnounceProverRequest{}
+	message.Announce = announce
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Join{
+			Join: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := announce.SignED448([]protobufs.ED448SignHelper{
+		{
+			PublicKey: primaryPublicKeyBytes,
+			Sign:      primaryPrivateKey.Sign,
+		},
+		{
+			PublicKey: secondaryPublicKeyBytes,
+			Sign:      secondaryPrivateKey.Sign,
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Join{
+			Join: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnounceProverLeaveValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.AnnounceProverLeave)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.AnnounceProverLeave{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Leave{
+			Leave: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Filter = bytes.Repeat([]byte{0x01}, 32)
+	message.FrameNumber = 1
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Leave{
+			Leave: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnounceProverPauseValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.AnnounceProverPause)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.AnnounceProverPause{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Pause{
+			Pause: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Filter = bytes.Repeat([]byte{0x01}, 32)
+	message.FrameNumber = 1
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Pause{
+			Pause: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestAnnounceProverResumeValidate(t *testing.T) {
+	t.Parallel()
+	if err := (*protobufs.AnnounceProverResume)(nil).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message := &protobufs.AnnounceProverResume{}
+	if err := message.Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Resume{
+			Resume: message,
+		},
+	}).Validate(); err == nil {
+		t.Fatal("expected error")
+	}
+	message.Filter = bytes.Repeat([]byte{0x01}, 32)
+	message.FrameNumber = 1
+	if err := message.SignED448(primaryPublicKeyBytes, primaryPrivateKey.Sign); err != nil {
+		t.Fatal(err)
+	}
+	if err := message.Validate(); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&protobufs.TokenRequest{
+		Request: &protobufs.TokenRequest_Resume{
+			Resume: message,
+		},
+	}).Validate(); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/node/rpc/node_rpc_server.go
+++ b/node/rpc/node_rpc_server.go
@@ -221,20 +221,20 @@ func (r *RPCServer) SendMessage(
 ) (*protobufs.SendMessageResponse, error) {
 	req.Timestamp = time.Now().UnixMilli()
 
-	any := &anypb.Any{}
-	if err := any.MarshalFrom(req); err != nil {
+	a := &anypb.Any{}
+	if err := a.MarshalFrom(req); err != nil {
 		return nil, errors.Wrap(err, "publish message")
 	}
 
 	// annoying protobuf any hack
-	any.TypeUrl = strings.Replace(
-		any.TypeUrl,
+	a.TypeUrl = strings.Replace(
+		a.TypeUrl,
 		"type.googleapis.com",
 		"types.quilibrium.com",
 		1,
 	)
 
-	payload, err := proto.Marshal(any)
+	payload, err := proto.Marshal(a)
 	if err != nil {
 		return nil, errors.Wrap(err, "publish message")
 	}


### PR DESCRIPTION
This PR is a big refactor which attempts to solve the following issues:
- Message validation for token requests is heavily fragmented. We validated very late, as part of the frame application process, and the validation logic is spread in multiple places.
- Building signatures, and verifying signatures, is generally duplicated throughout the code base, and generally quite long.

It achieves this via the following system:
- Messages now have a `Validate` method, which checks recursively checks the message fields for validity (fields are not `nil`, they have the right length, signatures match).
- Messages now have a `ValidateSignature` method which checks the signature of the message based on its contents. `ValidateSignature` expects that the message is valid, and is automatically called by `Validate`.
- Messages now have a `SignED448` method which builds an ED448 signature based on the message contents.
- A `TokenRequest()` method has been added to the concrete token requests type in order to simplify how requests are built.
- Unit tests have been added that check:
  - Message contents validation (`nil` messages, missing fields).
  - Signature contents validation.
  - Signature payload checks (looking at the bytes which are signed/verified).

Tests ran on testnet:
- Automatic join prover ring (and single key announce) ✅ .
- Automatic mint via proofs ✅ .
- Automatic merge all coins ✅ .
- Manual merge all coins ✅ .
- Manual merge some coins ✅ .
- Manual split coins ✅ .
- Manual transfer coins ✅ .