### PR TITLE
Do not clone full tries

### DIFF
--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -116,6 +116,9 @@ func (e *DataClockConsensusEngine) prove(
 		"applied transitions",
 		zap.Int("successful", len(validTransactions.Requests)),
 		zap.Int("failed", len(invalidTransactions.Requests)),
+		zap.Uint64("mint_out_of_order", app.MintOutOfOrder),
+		zap.Uint64("mint_too_old", app.MintTooOld),
+		zap.Uint64("mint_tree_verification_failed", app.MintTreeVerificationFailure),
 	)
 
 	outputState, err := app.MaterializeStateFromApplication()

--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -222,7 +222,7 @@ func (e *DataClockConsensusEngine) prove(
 }
 
 func (e *DataClockConsensusEngine) GetAheadPeers(frameNumber uint64) []internal.PeerCandidate {
-	if e.GetFrameProverTries()[0].Contains(e.provingKeyAddress) {
+	if e.GetFrameProverTrie(0).Contains(e.provingKeyAddress) {
 		return nil
 	}
 

--- a/node/consensus/data/message_handler.go
+++ b/node/consensus/data/message_handler.go
@@ -182,7 +182,7 @@ func (e *DataClockConsensusEngine) handleClockFrame(
 		return errors.Wrap(err, "handle clock frame data")
 	}
 
-	trie := e.GetFrameProverTries()[0]
+	trie := e.GetFrameProverTrie(0)
 	if !trie.Contains(addr.FillBytes(make([]byte, 32))) {
 		e.logger.Debug(
 			"prover not in trie at frame, address may be in fork",
@@ -369,7 +369,7 @@ func TokenRequestIdentifiers(transition *protobufs.TokenRequest) []string {
 func (e *DataClockConsensusEngine) handleTokenRequest(
 	transition *protobufs.TokenRequest,
 ) error {
-	if e.GetFrameProverTries()[0].Contains(e.provingKeyAddress) {
+	if e.GetFrameProverTrie(0).Contains(e.provingKeyAddress) {
 		identifiers := TokenRequestIdentifiers(transition)
 
 		e.stagedTransactionsMx.Lock()

--- a/node/consensus/data/peer_messaging.go
+++ b/node/consensus/data/peer_messaging.go
@@ -128,7 +128,7 @@ func (e *DataClockConsensusEngine) GetPreMidnightMintStatus(
 	ctx context.Context,
 	t *protobufs.PreMidnightMintStatusRequest,
 ) (*protobufs.PreMidnightMintResponse, error) {
-	if !e.GetFrameProverTries()[0].Contains(e.provingKeyAddress) {
+	if !e.GetFrameProverTrie(0).Contains(e.provingKeyAddress) {
 		return nil, errors.Wrap(
 			errors.New("wrong destination"),
 			"get pre midnight mint status",
@@ -182,7 +182,7 @@ func (e *DataClockConsensusEngine) GetPreMidnightMintStatus(
 func (e *DataClockConsensusEngine) handleMint(
 	t *protobufs.MintCoinRequest,
 ) ([]byte, error) {
-	if !e.GetFrameProverTries()[0].Contains(e.provingKeyAddress) {
+	if !e.GetFrameProverTrie(0).Contains(e.provingKeyAddress) {
 		return nil, errors.Wrap(errors.New("wrong destination"), "handle mint")
 	}
 
@@ -243,7 +243,7 @@ func (e *DataClockConsensusEngine) handleMint(
 			t.Proofs[0],
 			[]byte("pre-dusk"),
 		) && (!bytes.Equal(t.Proofs[1], make([]byte, 32)) ||
-		time.Now().Unix() < 1730523600) && e.GetFrameProverTries()[0].Contains(
+		time.Now().Unix() < 1730523600) && e.GetFrameProverTrie(0).Contains(
 		e.provingKeyAddress,
 	) {
 		prevInput := []byte{}


### PR DESCRIPTION
This PR avoids a full trie set clone when checking for beacon presence. It also adds some additional logging.