### PR TITLE
Change message size limits

### DIFF
--- a/go-libp2p-blossomsub/pubsub.go
+++ b/go-libp2p-blossomsub/pubsub.go
@@ -26,8 +26,8 @@ import (
 	logging "github.com/ipfs/go-log/v2"
 )
 
-// DefaultSoftMaxMessageSize is 10 MiB.
-const DefaultSoftMaxMessageSize = 10 << 20
+// DefaultSoftMaxMessageSize is 1 MiB.
+const DefaultSoftMaxMessageSize = 1 << 20
 
 // DefaultHardMaxMessageSize is 20 MB.
 const DefaultHardMaxMessageSize = 10 << 21

--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -331,8 +331,8 @@ func (e *DataClockConsensusEngine) Start() <-chan error {
 	e.pubSub.Subscribe(e.infoFilter, e.handleInfoMessage)
 	go func() {
 		server := qgrpc.NewServer(
-			grpc.MaxSendMsgSize(20*1024*1024),
-			grpc.MaxRecvMsgSize(20*1024*1024),
+			grpc.MaxSendMsgSize(40*1024*1024),
+			grpc.MaxRecvMsgSize(40*1024*1024),
 		)
 		protobufs.RegisterDataServiceServer(server, e)
 		if err := e.pubSub.StartDirectChannelListener(


### PR DESCRIPTION
This PR introduces the following changes:
- The built in sync RPC server message limits have been increased to 40 MiB, in order to allow larger frames to be sent via it.
- The soft max message size limit in the PubSub has been lowered to 1 MiB. Note that the soft limit only affects batched messages (like `IHAVE`, `IWANT`, `IDONTWANT` and multiple `PUBLISH` messages as a result of an `IWANT`).
  - This change improves latency by allowing messages to be received by the requesting peer faster, thus allowing this peer to emit `IDONTWANT` messages to its mesh, and to start heartbeating them as well.
  - Large messages are still allowed on the mesh, but longer term we need to get rid of them. They cause massive delays as they cannot be passed forward while being downloaded.