### PR TITLE
Separate dialing timeout from retrieval timeout during sync

### DIFF
--- a/client/cmd/all.go
+++ b/client/cmd/all.go
@@ -89,8 +89,9 @@ var allCmd = &cobra.Command{
 			panic(errors.Wrap(err, "error getting peer id"))
 		}
 
+		ctx := context.Background()
 		resume := make([]byte, 32)
-		cc, err := pubSub.GetDirectChannel([]byte(bpeerId), "worker")
+		cc, err := pubSub.GetDirectChannel(ctx, []byte(bpeerId), "worker")
 		if err != nil {
 			logger.Info(
 				"could not establish direct channel, waiting...",
@@ -100,7 +101,7 @@ var allCmd = &cobra.Command{
 		}
 		for {
 			if cc == nil {
-				cc, err = pubSub.GetDirectChannel([]byte(bpeerId), "worker")
+				cc, err = pubSub.GetDirectChannel(ctx, []byte(bpeerId), "worker")
 				if err != nil {
 					logger.Info(
 						"could not establish direct channel, waiting...",

--- a/node/consensus/data/peer_messaging.go
+++ b/node/consensus/data/peer_messaging.go
@@ -636,7 +636,7 @@ func (e *DataClockConsensusEngine) GetPublicChannelForProvingKey(
 			)
 		}
 	} else {
-		cc, err := e.pubSub.GetDirectChannel(peerID, base58.Encode(provingKey))
+		cc, err := e.pubSub.GetDirectChannel(e.ctx, peerID, base58.Encode(provingKey))
 		if err != nil {
 			e.logger.Error(
 				"could not get public channel for proving key",

--- a/node/consensus/data/pre_midnight_proof_worker.go
+++ b/node/consensus/data/pre_midnight_proof_worker.go
@@ -85,7 +85,7 @@ func (e *DataClockConsensusEngine) runPreMidnightProofWorker() {
 	}
 
 	resume := make([]byte, 32)
-	cc, err := e.pubSub.GetDirectChannel([]byte(peerId), "worker")
+	cc, err := e.pubSub.GetDirectChannel(e.ctx, []byte(peerId), "worker")
 	if err != nil {
 		e.logger.Info(
 			"could not establish direct channel, waiting...",
@@ -110,7 +110,7 @@ func (e *DataClockConsensusEngine) runPreMidnightProofWorker() {
 		}
 
 		if cc == nil {
-			cc, err = e.pubSub.GetDirectChannel([]byte(peerId), "worker")
+			cc, err = e.pubSub.GetDirectChannel(e.ctx, []byte(peerId), "worker")
 			if err != nil {
 				e.logger.Info(
 					"could not establish direct channel, waiting...",

--- a/node/consensus/data/token_handle_mint_test.go
+++ b/node/consensus/data/token_handle_mint_test.go
@@ -64,7 +64,7 @@ func (pubsub) StartDirectChannelListener(
 ) error {
 	return nil
 }
-func (pubsub) GetDirectChannel(peerId []byte, purpose string) (*grpc.ClientConn, error) {
+func (pubsub) GetDirectChannel(ctx context.Context, peerId []byte, purpose string) (*grpc.ClientConn, error) {
 	return nil, nil
 }
 func (pubsub) GetNetworkInfo() *protobufs.NetworkInfoResponse {

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -937,7 +937,7 @@ func (c *extraCloseConn) Close() error {
 	return err
 }
 
-func (b *BlossomSub) GetDirectChannel(peerID []byte, purpose string) (
+func (b *BlossomSub) GetDirectChannel(ctx context.Context, peerID []byte, purpose string) (
 	cc *grpc.ClientConn, err error,
 ) {
 	// Kind of a weird hack, but gostream can induce panics if the peer drops at
@@ -954,7 +954,7 @@ func (b *BlossomSub) GetDirectChannel(peerID []byte, purpose string) (
 	// Open question: should we prefix this so a node can run both in mainnet and
 	// testnet? Feels like a bad idea and would be preferable to discourage.
 	cc, err = qgrpc.DialContext(
-		b.ctx,
+		ctx,
 		"passthrough:///",
 		grpc.WithContextDialer(
 			func(ctx context.Context, _ string) (net.Conn, error) {
@@ -991,6 +991,7 @@ func (b *BlossomSub) GetDirectChannel(peerID []byte, purpose string) (
 			},
 		),
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithBlock(),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "dial context")

--- a/node/p2p/pubsub.go
+++ b/node/p2p/pubsub.go
@@ -44,7 +44,7 @@ type PubSub interface {
 		purpose string,
 		server *grpc.Server,
 	) error
-	GetDirectChannel(peerId []byte, purpose string) (*grpc.ClientConn, error)
+	GetDirectChannel(ctx context.Context, peerId []byte, purpose string) (*grpc.ClientConn, error)
 	GetNetworkInfo() *protobufs.NetworkInfoResponse
 	SignMessage(msg []byte) ([]byte, error)
 	GetPublicKey() []byte


### PR DESCRIPTION
This PR adapts the sync timeout mechanism to separate dialing a peer (which is more likely to fail if the peer is behind a NAT), from the actual retrieval (the RPC that returns the frame). This should alleviate the need for large timeouts in the case of large frames (which require more wall time to be transferred).