### PR TITLE
Avoid pooling large buffers

### DIFF
--- a/go-libp2p-blossomsub/comm.go
+++ b/go-libp2p-blossomsub/comm.go
@@ -169,11 +169,10 @@ func (p *PubSub) handlePeerDead(s network.Stream) {
 }
 
 func (p *PubSub) handleSendingMessages(ctx context.Context, s network.Stream, q *rpcQueue) {
-	getBuffer, returnLastBuffer := makeBufferSource()
-	defer returnLastBuffer()
 	writeRPC := func(rpc *RPC) error {
 		size := uint64(rpc.Size())
-		buf := getBuffer(varint.UvarintSize(size) + int(size))
+		buf := pool.Get(varint.UvarintSize(size) + int(size))
+		defer pool.Put(buf)
 		n := binary.PutUvarint(buf, size)
 		_, err := rpc.MarshalTo(buf[n:])
 		if err != nil {
@@ -234,29 +233,4 @@ func copyRPC(rpc *RPC) *RPC {
 	*res = *rpc
 	res.RPC = (proto.Clone(rpc.RPC)).(*pb.RPC)
 	return res
-}
-
-// makeBufferSource returns a function that can be used to allocate buffers of
-// a given size, and a function that can be used to return the last buffer
-// allocated.
-// The returned function will attempt to reuse the last buffer allocated if
-// the requested size is less than or equal to the capacity of the last buffer.
-// If the requested size is greater than the capacity of the last buffer, the
-// last buffer is returned to the pool and a new buffer is allocated.
-// If the requested size is less than or equal to half the capacity of the last
-// buffer, the last buffer is returned to the pool and a new buffer is allocated.
-func makeBufferSource() (func(int) []byte, func()) {
-	b := pool.Get(0)
-	mk := func(n int) []byte {
-		if c := cap(b); c/2 < n && n <= c {
-			return b[:n]
-		}
-		pool.Put(b)
-		b = pool.Get(n)
-		return b
-	}
-	rt := func() {
-		pool.Put(b)
-	}
-	return mk, rt
 }


### PR DESCRIPTION
References https://github.com/QuilibriumNetwork/ceremonyclient/pull/397
References https://github.com/golang/go/commit/2dcbf8b3691e72d1b04e9376488cef3b6f93b286

I finally have a reproduction for the death spiral which happens as the node approaches `GOMEMLIMIT` heap usage. It can be reproduced quite fast by using a _low_ `GOMEMLIMIT`, like `4GiB`. This PR tracks my attempts to deal with this death spiral.

Update 1: The `GOGC` value, no matter how big or small, does not help with the death spiral. At this point it really seems that we're resurrecting the items in the buffer `sync.Pool` too fast for them to be ever garbage collected (see the referenced runtime commit).

Update 2: By stopping the pooling of the large send buffers, I no longer observe permanent death spirals. In this context a permanent death spiral is basically a master node whose CPU usage is permanently high on multiple cores and when profile the time is spent on the GC.
I have moments when my small 4GiB heap needs to be scrubbed, and during these times the CPU usage spikes temporarily, but, compared to the previous behavior, this procedure actually ends and memory is freed, so things are promising so far.

Update 3: I have updated also the receive side to avoid pooling large buffers, as these can accumulate as well.