### PR TITLE
Increase subscription buffer size

### DIFF
--- a/go-libp2p-blossomsub/bitmask.go
+++ b/go-libp2p-blossomsub/bitmask.go
@@ -13,6 +13,9 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
+// DefaultSubscriptionQueueSize is the default size of the subscription queue.
+const DefaultSubscriptionQueueSize = 16384
+
 // ErrBitmaskClosed is returned if a Bitmask is utilized after it has been closed
 var ErrBitmaskClosed = errors.New("this Bitmask is closed, try opening a new one")
 
@@ -167,7 +170,7 @@ func (t *Bitmask) Subscribe(opts ...SubOpt) (*Subscription, error) {
 	}
 
 	if sub.ch == nil {
-		sub.ch = make(chan *Message, 32)
+		sub.ch = make(chan *Message, DefaultSubscriptionQueueSize)
 	}
 
 	out := make(chan *Subscription, 1)

--- a/node/config/p2p.go
+++ b/node/config/p2p.go
@@ -53,4 +53,5 @@ type P2PConfig struct {
 	PingAttempts              int           `yaml:"pingAttempts"`
 	ValidateQueueSize         int           `yaml:"validateQueueSize"`
 	ValidateWorkers           int           `yaml:"validateWorkers"`
+	SubscriptionQueueSize     int           `yaml:"subscriptionQueueSize"`
 }


### PR DESCRIPTION
This PR increases the default subscription buffer size from 32 messages to 16384 messages, in order to avoid buffer drops when multiple messages arrive at the same time in bursts. This fixes the loss of frame fragments on test net, and may even help with some transaction drops on main net.

You may wonder 'how does it happen that we saturate the subscriber', and the answer is that sometimes when messages arrive really quickly (via an `IWANT` perhaps), there is zero delay between the messages while they are pushed to the subscription queue - they are just iterated and pushed, and it can be the case that the consumer goroutine misses some messages.