### PR TITLE
Increase gossip history and length

### DIFF
--- a/go-libp2p-blossomsub/blossomsub.go
+++ b/go-libp2p-blossomsub/blossomsub.go
@@ -37,8 +37,8 @@ var (
 	BlossomSubDhi                              = 12
 	BlossomSubDscore                           = 4
 	BlossomSubDout                             = 2
-	BlossomSubHistoryLength                    = 5
-	BlossomSubHistoryGossip                    = 3
+	BlossomSubHistoryLength                    = 9
+	BlossomSubHistoryGossip                    = 6
 	BlossomSubDlazy                            = 6
 	BlossomSubGossipFactor                     = 0.25
 	BlossomSubGossipRetransmission             = 3

--- a/go-libp2p-blossomsub/pubsub.go
+++ b/go-libp2p-blossomsub/pubsub.go
@@ -32,6 +32,9 @@ const DefaultSoftMaxMessageSize = 1 << 20
 // DefaultHardMaxMessageSize is 20 MB.
 const DefaultHardMaxMessageSize = 10 << 21
 
+// DefaultPeerOutboundQueueSize is the default size of the outbound message channel that we maintain for each peer.
+const DefaultPeerOutboundQueueSize = 128
+
 var (
 	// TimeCacheDuration specifies how long a message ID will be remembered as seen.
 	// Use WithSeenMessagesTTL to configure this per pubsub instance, instead of overriding the global default.

--- a/node/config/p2p.go
+++ b/node/config/p2p.go
@@ -54,4 +54,5 @@ type P2PConfig struct {
 	ValidateQueueSize         int           `yaml:"validateQueueSize"`
 	ValidateWorkers           int           `yaml:"validateWorkers"`
 	SubscriptionQueueSize     int           `yaml:"subscriptionQueueSize"`
+	PeerOutboundQueueSize     int           `yaml:"peerOutboundQueueSize"`
 }

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -476,6 +476,7 @@ func NewBlossomSub(
 	blossomOpts = append(blossomOpts,
 		blossomsub.WithValidateQueueSize(p2pConfig.ValidateQueueSize),
 		blossomsub.WithValidateWorkers(p2pConfig.ValidateWorkers),
+		blossomsub.WithPeerOutboundQueueSize(p2pConfig.PeerOutboundQueueSize),
 	)
 	blossomOpts = append(blossomOpts, observability.WithPrometheusRawTracer())
 	blossomOpts = append(blossomOpts, blossomsub.WithPeerFilter(internal.NewStaticPeerFilter(
@@ -1173,6 +1174,9 @@ func withDefaults(p2pConfig *config.P2PConfig) *config.P2PConfig {
 	}
 	if p2pConfig.SubscriptionQueueSize == 0 {
 		p2pConfig.SubscriptionQueueSize = blossomsub.DefaultSubscriptionQueueSize
+	}
+	if p2pConfig.PeerOutboundQueueSize == 0 {
+		p2pConfig.PeerOutboundQueueSize = blossomsub.DefaultPeerOutboundQueueSize
 	}
 	return p2pConfig
 }


### PR DESCRIPTION
This PR increases the gossip history and length in order to accommodate an old change that we did, when we moved the gossip interval from one second to 0.7 seconds.