### PR TITLE
Use default in BlossomSub

### DIFF
--- a/go-libp2p-blossomsub/pubsub.go
+++ b/go-libp2p-blossomsub/pubsub.go
@@ -276,7 +276,7 @@ func NewPubSub(ctx context.Context, h host.Host, rt PubSubRouter, opts ...Option
 		disc:                  &discover{},
 		softMaxMessageSize:    DefaultSoftMaxMessageSize,
 		hardMaxMessageSize:    DefaultHardMaxMessageSize,
-		peerOutboundQueueSize: 32,
+		peerOutboundQueueSize: DefaultPeerOutboundQueueSize,
 		signID:                h.ID(),
 		signKey:               nil,
 		signPolicy:            LaxSign,


### PR DESCRIPTION
This PR fixes the fact that the default peer outbound queue size is not used in BlossomSub by default. It is just technical debt - we don't need a new build with this change, because we already override this with our config value.