### PR TITLE
enhance worker connection failure logging

### DIFF
--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -940,7 +940,8 @@ func (e *DataClockConsensusEngine) createParallelDataClientsFromList() (
 	clients := make([]protobufs.DataIPCServiceClient, parallelism)
 
 	for i := 0; i < parallelism; i++ {
-		ma, err := multiaddr.NewMultiaddr(e.config.Engine.DataWorkerMultiaddrs[i])
+		wma := e.config.Engine.DataWorkerMultiaddrs[i]
+		ma, err := multiaddr.NewMultiaddr(wma)
 		if err != nil {
 			panic(err)
 		}
@@ -966,7 +967,7 @@ func (e *DataClockConsensusEngine) createParallelDataClientsFromList() (
 			grpc.WithBlock(),
 		)
 		if err != nil {
-			e.logger.Error("could not dial", zap.Error(err))
+			e.logger.Error("could not dial", zap.Int("core", i), zap.String("worker multiaddr", wma), zap.Error(err))
 			continue
 		}
 

--- a/node/consensus/data/data_clock_consensus_engine.go
+++ b/node/consensus/data/data_clock_consensus_engine.go
@@ -967,7 +967,7 @@ func (e *DataClockConsensusEngine) createParallelDataClientsFromList() (
 			grpc.WithBlock(),
 		)
 		if err != nil {
-			e.logger.Error("could not dial", zap.Int("core", i), zap.String("worker multiaddr", wma), zap.Error(err))
+			e.logger.Error("could not dial", zap.Int("core", i), zap.String("worker_multiaddr", wma), zap.Error(err))
 			continue
 		}
 


### PR DESCRIPTION
Currently, when the worker connection fails, the master process prints only the error message, which does not help to identify the worker in any way.
This PR aims to print the worker multiaddr, so the node operator can get actionable data to fix the connection between the master and the failing worker.