### PR TITLE
Limit sync candidates

### DIFF
--- a/node/config/engine.go
+++ b/node/config/engine.go
@@ -94,6 +94,8 @@ type EngineConfig struct {
 	AutoMergeCoins bool `yaml:"autoMergeCoins"`
 	// Maximum wait time for a frame to be downloaded from a peer.
 	SyncTimeout time.Duration `yaml:"syncTimeout"`
+	// Number of candidate peers per category to sync with.
+	SyncCandidates int `yaml:"syncCandidates"`
 
 	// Values used only for testing – do not override these in production, your
 	// node will get kicked out

--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -20,7 +20,10 @@ import (
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
 )
 
-const defaultSyncTimeout = 4 * time.Second
+const (
+	defaultSyncTimeout    = 4 * time.Second
+	defaultSyncCandidates = 8
+)
 
 func (e *DataClockConsensusEngine) syncWithMesh() error {
 	e.logger.Info("collecting vdf proofs")
@@ -304,11 +307,16 @@ func (e *DataClockConsensusEngine) GetAheadPeers(frameNumber uint64) []internal.
 		}
 	}
 
+	syncCandidates := e.config.Engine.SyncCandidates
+	if syncCandidates == 0 {
+		syncCandidates = defaultSyncCandidates
+	}
+
 	return slices.Concat(
-		internal.WeightedSampleWithoutReplacement(nearCandidates, len(nearCandidates)),
-		internal.WeightedSampleWithoutReplacement(reachableCandidates, len(reachableCandidates)),
-		internal.WeightedSampleWithoutReplacement(unknownCandidates, len(unknownCandidates)),
-		internal.WeightedSampleWithoutReplacement(unreachableCandidates, len(unreachableCandidates)),
+		internal.WeightedSampleWithoutReplacement(nearCandidates, min(len(nearCandidates), syncCandidates)),
+		internal.WeightedSampleWithoutReplacement(reachableCandidates, min(len(reachableCandidates), syncCandidates)),
+		internal.WeightedSampleWithoutReplacement(unknownCandidates, min(len(unknownCandidates), syncCandidates)),
+		internal.WeightedSampleWithoutReplacement(unreachableCandidates, min(len(unreachableCandidates), syncCandidates)),
 	)
 }
 


### PR DESCRIPTION
This PR limits the number of sync candidates which are considered for a single sync round to a configurable value. The reason is that we can end up having to test many unreachable peers while we could sync with other reachable peers or peers which are already connected to the node, but of which we became aware while a sync round was ongoing.