### PR TITLE
Change default GOGC to 10

### DIFF
--- a/node/consensus/data/message_handler.go
+++ b/node/consensus/data/message_handler.go
@@ -110,7 +110,7 @@ func (e *DataClockConsensusEngine) runTxMessageHandler() {
 				continue
 			}
 
-			if e.frameProverTries[0].Contains(e.provingKeyAddress) {
+			if e.FrameProverTrieContains(0, e.provingKeyAddress) {
 				wg := &sync.WaitGroup{}
 				for name := range e.executionEngines {
 					name := name

--- a/node/main.go
+++ b/node/main.go
@@ -476,6 +476,9 @@ func main() {
 			if _, explicitGOMEMLIMIT := os.LookupEnv("GOMEMLIMIT"); !explicitGOMEMLIMIT {
 				rdebug.SetMemoryLimit(availableOverhead * 8 / 10)
 			}
+			if _, explicitGOGC := os.LookupEnv("GOGC"); !explicitGOGC {
+				rdebug.SetGCPercent(10)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR proposes that the default `GOGC` is changed to `10` for cases in which the memory limit is set. This has been extensively tested and in practice keeps the heap size in check for prolonged periods of time.