### PR TITLE
pause frame sync iteration until head catches up with the last synced frame

### DIFF
--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -60,6 +60,18 @@ func (e *DataClockConsensusEngine) syncWithMesh() error {
 		zap.Uint64("frame_number", latest.FrameNumber),
 		zap.Duration("frame_age", frametime.Since(latest)),
 	)
+	
+	for {
+		head, err := e.dataTimeReel.Head()
+		if err != nil {
+			return errors.Wrap(err, "sync")
+		}
+		if latest.FrameNumber <= head.FrameNumber {
+			break
+		}
+		e.logger.Info("synced beyond head, waiting for head to catch up")
+		time.Sleep(60 * time.Second)
+	}
 
 	return nil
 }


### PR DESCRIPTION
In the cold node startup scenario, the frame sync done by `consensus_frames` goes in parallel with the frame processing done by `token_execution_engine`.

As in the full prover model the frame processing takes more time than frame sync, this leads to multiple frame sync iterations targeting **overlapping** frame ranges that actively interfere with frame processing by consuming valuable resources.

This PR aims to **pause** the frame sync iteration in order to let the `token_execution_engine` catch up with the last synced frame before `main_data_loop` can request the new frame sync iteration.