### PR TITLE
Wait frame processing on sync end

### DIFF
--- a/node/consensus/data/main_data_loop.go
+++ b/node/consensus/data/main_data_loop.go
@@ -275,7 +275,9 @@ func (e *DataClockConsensusEngine) processFrame(
 			return dataFrame
 		}
 
-		e.dataTimeReel.Insert(e.ctx, nextFrame, true)
+		if _, err := e.dataTimeReel.Insert(e.ctx, nextFrame); err != nil {
+			e.logger.Debug("could not insert frame", zap.Error(err))
+		}
 
 		return nextFrame
 	} else {

--- a/node/consensus/data/message_handler.go
+++ b/node/consensus/data/message_handler.go
@@ -253,7 +253,9 @@ func (e *DataClockConsensusEngine) handleClockFrame(
 	}
 
 	if frame.FrameNumber > head.FrameNumber {
-		e.dataTimeReel.Insert(e.ctx, frame, false)
+		if _, err := e.dataTimeReel.Insert(e.ctx, frame); err != nil {
+			e.logger.Debug("could not insert frame", zap.Error(err))
+		}
 	}
 
 	return nil

--- a/node/consensus/master/broadcast_messaging.go
+++ b/node/consensus/master/broadcast_messaging.go
@@ -155,7 +155,7 @@ func (e *MasterClockConsensusEngine) publishProof(
 			zap.Uint64("frame_number", frame.FrameNumber),
 		)
 
-		e.masterTimeReel.Insert(context.TODO(), frame, false)
+		e.masterTimeReel.Insert(context.TODO(), frame)
 	}
 
 	e.state = consensus.EngineStateCollecting

--- a/node/consensus/master/master_clock_consensus_engine.go
+++ b/node/consensus/master/master_clock_consensus_engine.go
@@ -208,7 +208,7 @@ func (e *MasterClockConsensusEngine) Start() <-chan error {
 					continue
 				}
 
-				e.masterTimeReel.Insert(context.TODO(), newFrame, false)
+				e.masterTimeReel.Insert(context.TODO(), newFrame)
 			}
 		}
 	}()

--- a/node/consensus/time/data_time_reel_test.go
+++ b/node/consensus/time/data_time_reel_test.go
@@ -233,7 +233,7 @@ func TestDataTimeReel(t *testing.T) {
 			i+1,
 			10,
 		)
-		d.Insert(ctx, frame, false)
+		d.Insert(ctx, frame)
 		prevBI, _ := frame.GetSelector()
 		prev = prevBI.FillBytes(make([]byte, 32))
 	}
@@ -264,7 +264,7 @@ func TestDataTimeReel(t *testing.T) {
 	}
 
 	for i := 99; i >= 0; i-- {
-		err := d.Insert(ctx, insertFrames[i], false)
+		_, err := d.Insert(ctx, insertFrames[i])
 		assert.NoError(t, err)
 	}
 
@@ -286,7 +286,7 @@ func TestDataTimeReel(t *testing.T) {
 			i+1,
 			10,
 		)
-		d.Insert(ctx, frame, false)
+		d.Insert(ctx, frame)
 
 		prevBI, _ := frame.GetSelector()
 		prev = prevBI.FillBytes(make([]byte, 32))
@@ -334,7 +334,7 @@ func TestDataTimeReel(t *testing.T) {
 	}
 
 	for i := 99; i >= 0; i-- {
-		err := d.Insert(ctx, insertFrames[i], false)
+		_, err := d.Insert(ctx, insertFrames[i])
 		assert.NoError(t, err)
 	}
 
@@ -397,7 +397,7 @@ func TestDataTimeReel(t *testing.T) {
 
 	// Someone is honest, but running backwards:
 	for i := 99; i >= 0; i-- {
-		err := d.Insert(ctx, insertFrames[i], false)
+		_, err := d.Insert(ctx, insertFrames[i])
 		gotime.Sleep(1 * gotime.Second)
 		assert.NoError(t, err)
 	}

--- a/node/consensus/time/master_time_reel.go
+++ b/node/consensus/time/master_time_reel.go
@@ -123,13 +123,12 @@ func (m *MasterTimeReel) Head() (*protobufs.ClockFrame, error) {
 func (m *MasterTimeReel) Insert(
 	ctx context.Context,
 	frame *protobufs.ClockFrame,
-	isSync bool,
-) error {
+) (<-chan struct{}, error) {
 	go func() {
 		m.frames <- frame
 	}()
 
-	return nil
+	return alreadyDone, nil
 }
 
 // NewFrameCh implements TimeReel.

--- a/node/consensus/time/master_time_reel_test.go
+++ b/node/consensus/time/master_time_reel_test.go
@@ -61,7 +61,7 @@ func TestMasterTimeReel(t *testing.T) {
 		)
 		assert.NoError(t, err)
 
-		err := m.Insert(ctx, frame, false)
+		_, err := m.Insert(ctx, frame)
 		assert.NoError(t, err)
 	}
 
@@ -81,7 +81,7 @@ func TestMasterTimeReel(t *testing.T) {
 	}
 
 	for i := 99; i >= 0; i-- {
-		err := m.Insert(ctx, insertFrames[i], false)
+		_, err := m.Insert(ctx, insertFrames[i])
 		assert.NoError(t, err)
 	}
 

--- a/node/consensus/time/time_reel.go
+++ b/node/consensus/time/time_reel.go
@@ -9,7 +9,7 @@ import (
 type TimeReel interface {
 	Start() error
 	Stop()
-	Insert(ctx context.Context, frame *protobufs.ClockFrame, isSync bool) error
+	Insert(ctx context.Context, frame *protobufs.ClockFrame) (<-chan struct{}, error)
 	Head() (*protobufs.ClockFrame, error)
 	NewFrameCh() <-chan *protobufs.ClockFrame
 	BadFrameCh() <-chan *protobufs.ClockFrame


### PR DESCRIPTION
References https://github.com/QuilibriumNetwork/ceremonyclient/pull/411

This is an alternative to #411 with the following two advantages:
- It respect context cancellations, so it won't delay the closure of the main process.
- It awaits the actual frames which have been inserted by the sync process, so even if the processing fails, it can still progress.