### PR TITLE
improve logging

### DIFF
--- a/node/consensus/data/consensus_frames.go
+++ b/node/consensus/data/consensus_frames.go
@@ -11,6 +11,7 @@ import (
 	"source.quilibrium.com/quilibrium/monorepo/node/consensus/data/internal"
 	"source.quilibrium.com/quilibrium/monorepo/node/internal/frametime"
 	"source.quilibrium.com/quilibrium/monorepo/node/tries"
+	"source.quilibrium.com/quilibrium/monorepo/node/utils"
 
 	"github.com/iden3/go-iden3-crypto/poseidon"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -455,6 +456,7 @@ func (e *DataClockConsensusEngine) syncWithPeer(
 func (e *DataClockConsensusEngine) initiateProvers(
 	latestFrame *protobufs.ClockFrame,
 ) {
+	logger := utils.GetLogger()
 	if latestFrame.Timestamp > time.Now().UnixMilli()-60000 {
 		if !e.IsInProverTrie(e.pubSub.GetPeerID()) {
 			e.logger.Info("announcing prover join")
@@ -470,7 +472,7 @@ func (e *DataClockConsensusEngine) initiateProvers(
 
 			h, err := poseidon.HashBytes(e.pubSub.GetPeerID())
 			if err != nil {
-				panic(err)
+				logger.Panic("could not hash peer id", zap.Error(err))
 			}
 			peerProvingKeyAddress := h.FillBytes(make([]byte, 32))
 

--- a/node/consensus/data/execution_registration.go
+++ b/node/consensus/data/execution_registration.go
@@ -17,7 +17,7 @@ func (e *DataClockConsensusEngine) RegisterExecutor(
 		for {
 			dataFrame, err := e.dataTimeReel.Head()
 			if err != nil {
-				panic(err)
+				e.logger.Panic("failed to get head frame", zap.Error(err))
 			}
 
 			logger.Info(
@@ -59,7 +59,7 @@ func (e *DataClockConsensusEngine) UnregisterExecutor(
 		for {
 			dataFrame, err := e.dataTimeReel.Head()
 			if err != nil {
-				panic(err)
+				e.logger.Panic("failed to get head frame", zap.Error(err))
 			}
 
 			logger.Info(

--- a/node/consensus/data/frame_importer.go
+++ b/node/consensus/data/frame_importer.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"source.quilibrium.com/quilibrium/monorepo/node/config"
 	"source.quilibrium.com/quilibrium/monorepo/node/store"
 )
@@ -237,7 +238,7 @@ func (e *DataClockConsensusEngine) applySnapshot(
 		false,
 	)
 	if err != nil {
-		fmt.Println("not found", max.FrameNumber+1)
+		e.logger.Error("snapshot not found", zap.Error(err), zap.Uint64("frame", max.FrameNumber+1))
 		temporaryStore.Close()
 		return errors.Wrap(
 			err,

--- a/node/consensus/data/main_data_loop.go
+++ b/node/consensus/data/main_data_loop.go
@@ -26,12 +26,12 @@ func (
 		newTrie := &tries.RollingFrecencyCritbitTrie{}
 		b, err := trie.Serialize()
 		if err != nil {
-			panic(err)
+			e.logger.Panic("failed to serialize trie", zap.Error(err))
 		}
 
 		err = newTrie.Deserialize(b)
 		if err != nil {
-			panic(err)
+			e.logger.Panic("failed to deserialize trie", zap.Error(err))
 		}
 		frameProverTries[i] = newTrie
 	}
@@ -49,10 +49,10 @@ func (e *DataClockConsensusEngine) GetFrameProverTrie(i int) *tries.RollingFrece
 	}
 	b, err := e.frameProverTries[i].Serialize()
 	if err != nil {
-		panic(err)
+		e.logger.Panic("failed to serialize trie", zap.Error(err))
 	}
 	if err := newTrie.Deserialize(b); err != nil {
-		panic(err)
+		e.logger.Panic("failed to deserialize trie", zap.Error(err))
 	}
 	return newTrie
 }
@@ -112,7 +112,7 @@ outer:
 		case <-time.After(1 * time.Minute):
 			head, err := e.dataTimeReel.Head()
 			if err != nil {
-				panic(err)
+				e.logger.Panic("failed to get head frame", zap.Error(err))
 			}
 
 			if head.FrameNumber <= maxFrames ||
@@ -193,14 +193,14 @@ func (e *DataClockConsensusEngine) runLoop() {
 		} else {
 			latestFrame, err := e.dataTimeReel.Head()
 			if err != nil {
-				panic(err)
+				e.logger.Panic("failed to get head frame", zap.Error(err))
 			}
 
 			if runOnce {
 				if e.FrameProverTrieContains(0, e.provingKeyAddress) {
 					dataFrame, err := e.dataTimeReel.Head()
 					if err != nil {
-						panic(err)
+						e.logger.Panic("failed to get head frame", zap.Error(err))
 					}
 
 					latestFrame = e.processFrame(latestFrame, dataFrame)

--- a/node/consensus/data/message_handler.go
+++ b/node/consensus/data/message_handler.go
@@ -17,6 +17,7 @@ import (
 	"source.quilibrium.com/quilibrium/monorepo/node/config"
 	"source.quilibrium.com/quilibrium/monorepo/node/execution/intrinsics/token/application"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
+	"source.quilibrium.com/quilibrium/monorepo/node/utils"
 )
 
 func (e *DataClockConsensusEngine) runFrameMessageHandler() {
@@ -255,7 +256,7 @@ func (e *DataClockConsensusEngine) handleClockFrame(
 
 	head, err := e.dataTimeReel.Head()
 	if err != nil {
-		panic(err)
+		e.logger.Panic("failed to get head frame", zap.Error(err))
 	}
 
 	if frame.FrameNumber > head.FrameNumber {
@@ -475,7 +476,9 @@ func TokenRequestIdentifiers(transition *protobufs.TokenRequest) []string {
 	case *protobufs.TokenRequest_Resume:
 		return []string{fmt.Sprintf("resume-%x", t.Resume.GetPublicKeySignatureEd448().PublicKey.KeyValue)}
 	default:
-		panic("unhandled transition type")
+		utils.GetLogger().Panic("unhandled token request type",
+			zap.String("transitionRequestType", fmt.Sprintf("%T", t)))
+		panic("unhandled token request type")
 	}
 }
 

--- a/node/consensus/data/message_validators.go
+++ b/node/consensus/data/message_validators.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"go.uber.org/zap"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"source.quilibrium.com/quilibrium/monorepo/go-libp2p-blossomsub/pb"
@@ -115,7 +116,7 @@ func (e *DataClockConsensusEngine) validateTxMessage(peerID peer.ID, message *pb
 
 			head, err := e.dataTimeReel.Head()
 			if err != nil {
-				panic(err)
+				e.logger.Panic("failed to get head", zap.Error(err))
 			}
 			if frameNumber+1 < head.FrameNumber {
 				return p2p.ValidationResultIgnore

--- a/node/consensus/data/prover_lookup.go
+++ b/node/consensus/data/prover_lookup.go
@@ -23,22 +23,19 @@ func (e *DataClockConsensusEngine) GetProvingKey(
 	}
 
 	if err != nil {
-		e.logger.Error("could not get proving key", zap.Error(err))
-		panic(err)
+		e.logger.Panic("could not get proving key", zap.Error(err))
 	}
 
 	rawKey, err := e.keyManager.GetRawKey(engineConfig.ProvingKeyId)
 	if err != nil {
-		e.logger.Error("could not get proving key type", zap.Error(err))
-		panic(err)
+		e.logger.Panic("could not get proving key type", zap.Error(err))
 	}
 
 	provingKeyType := rawKey.Type
 
 	h, err := poseidon.HashBytes(rawKey.PublicKey)
 	if err != nil {
-		e.logger.Error("could not hash proving key", zap.Error(err))
-		panic(err)
+		e.logger.Panic("could not hash proving key", zap.Error(err))
 	}
 
 	provingKeyAddress := h.Bytes()

--- a/node/consensus/master/broadcast_messaging.go
+++ b/node/consensus/master/broadcast_messaging.go
@@ -53,7 +53,7 @@ func (e *MasterClockConsensusEngine) handleClockFrameData(
 
 	head, err := e.masterTimeReel.Head()
 	if err != nil {
-		panic(err)
+		e.logger.Panic("failed to get head", zap.Error(err))
 	}
 
 	if frame.FrameNumber < head.FrameNumber {

--- a/node/consensus/master/consensus_frames.go
+++ b/node/consensus/master/consensus_frames.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"source.quilibrium.com/quilibrium/monorepo/node/consensus"
 	"source.quilibrium.com/quilibrium/monorepo/node/p2p"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
@@ -44,7 +45,7 @@ func (e *MasterClockConsensusEngine) GetMostAheadPeers() (
 ) {
 	frame, err := e.masterTimeReel.Head()
 	if err != nil {
-		panic(err)
+		e.logger.Panic("failed to get head", zap.Error(err))
 	}
 
 	// Needs to be enough to make the sync worthwhile:
@@ -74,7 +75,7 @@ func (e *MasterClockConsensusEngine) collect(
 ) (*protobufs.ClockFrame, error) {
 	latest, err := e.masterTimeReel.Head()
 	if err != nil {
-		panic(err)
+		e.logger.Panic("failed to get head", zap.Error(err))
 	}
 
 	return latest, nil

--- a/node/consensus/master/execution_registration.go
+++ b/node/consensus/master/execution_registration.go
@@ -17,7 +17,7 @@ func (e *MasterClockConsensusEngine) RegisterExecutor(
 	go func() {
 		masterFrame, err := e.masterTimeReel.Head()
 		if err != nil {
-			panic(err)
+			logger.Panic("could not get master time reel head", zap.Error(err))
 		}
 
 		logger.Info(
@@ -34,7 +34,7 @@ func (e *MasterClockConsensusEngine) RegisterExecutor(
 		for {
 			masterFrame, err = e.masterTimeReel.Head()
 			if err != nil {
-				panic(err)
+				logger.Panic("could not get master time reel head", zap.Error(err))
 			}
 
 			logger.Info(
@@ -86,7 +86,7 @@ func (e *MasterClockConsensusEngine) UnregisterExecutor(
 		for {
 			masterFrame, err := e.masterTimeReel.Head()
 			if err != nil {
-				panic(err)
+				logger.Panic("could not get master time reel head", zap.Error(err))
 			}
 
 			logger.Info(

--- a/node/consensus/master/master_clock_consensus_engine.go
+++ b/node/consensus/master/master_clock_consensus_engine.go
@@ -119,7 +119,7 @@ func NewMasterClockConsensusEngine(
 
 	e := &MasterClockConsensusEngine{
 		difficulty:           MASTER_CLOCK_RATE,
-		logger:               logger,
+		logger:               logger.With(zap.String("stage", "master-clock-consensus")),
 		state:                consensus.EngineStateStopped,
 		keyManager:           keyManager,
 		pubSub:               pubSub,

--- a/node/consensus/master/peer_messaging.go
+++ b/node/consensus/master/peer_messaging.go
@@ -32,7 +32,7 @@ func (e *MasterClockConsensusEngine) Sync(
 
 	masterFrame, err := e.masterTimeReel.Head()
 	if err != nil {
-		panic(err)
+		e.logger.Panic("could not get master time reel head", zap.Error(err))
 	}
 
 	if masterFrame.FrameNumber < from {

--- a/node/crypto/channel/tripleratchet.go
+++ b/node/crypto/channel/tripleratchet.go
@@ -9,7 +9,6 @@ import (
 	"crypto/subtle"
 	"encoding/binary"
 	"encoding/json"
-	"fmt"
 	"sort"
 
 	"github.com/pkg/errors"
@@ -17,6 +16,7 @@ import (
 	"source.quilibrium.com/quilibrium/monorepo/nekryptology/pkg/core/curves"
 	"source.quilibrium.com/quilibrium/monorepo/node/keys"
 	"source.quilibrium.com/quilibrium/monorepo/node/protobufs"
+	"source.quilibrium.com/quilibrium/monorepo/node/utils"
 )
 
 const TRIPLE_RATCHET_PROTOCOL_VERSION = 1
@@ -651,7 +651,7 @@ func (r *TripleRatchetParticipant) decryptHeader(
 		); err != nil {
 			return nil, false, errors.Wrap(err, "could not decrypt header")
 		}
-		fmt.Println("should ratchet")
+		utils.GetLogger().Info("should ratchet")
 		return header, true, nil
 	}
 

--- a/node/crypto/tree_compare.go
+++ b/node/crypto/tree_compare.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"slices"
 	"strings"
+
+	"go.uber.org/zap"
+	"source.quilibrium.com/quilibrium/monorepo/node/utils"
 )
 
 // CompareTreesAtHeight compares two vector commitment trees at each level
@@ -67,6 +70,7 @@ func compareLevelCommits(
 	node1, node2 LazyVectorCommitmentNode,
 	targetHeight, currentHeight int,
 ) []ComparisonResult {
+	logger := utils.GetLogger()
 	if node1 == nil && node2 == nil {
 		return nil
 	}
@@ -82,7 +86,7 @@ func compareLevelCommits(
 			} else if bok {
 				commit1 = branch1.Commitment
 			} else {
-				panic("invalid node type")
+				logger.Panic("invalid node type")
 			}
 		}
 		if node2 != nil {
@@ -93,7 +97,7 @@ func compareLevelCommits(
 			} else if bok {
 				commit2 = branch2.Commitment
 			} else {
-				panic("invalid node type")
+				logger.Panic("invalid node type")
 			}
 		}
 
@@ -332,7 +336,7 @@ func GetAllLeaves(
 					slices.Concat(n.FullPrefix, []int{i}),
 				)
 				if err != nil && !strings.Contains(err.Error(), "item not found") {
-					panic(err)
+					utils.GetLogger().Panic("failed to get node by path", zap.Error(err))
 				}
 			}
 			if child != nil {

--- a/node/crypto/wesolowski_frame_prover.go
+++ b/node/crypto/wesolowski_frame_prover.go
@@ -301,7 +301,7 @@ func (w *WesolowskiFrameProver) CreateDataGenesisFrame(
 	for i, s := range proverKeys {
 		addr, err := poseidon.HashBytes(s)
 		if err != nil {
-			panic(err)
+			w.logger.Panic("could not hash proving key", zap.Error(err))
 		}
 
 		addrBytes := addr.Bytes()

--- a/node/execution/intrinsics/token/token_genesis.go
+++ b/node/execution/intrinsics/token/token_genesis.go
@@ -515,14 +515,15 @@ func CreateGenesisState(
 	[][]byte,
 	map[string]uint64,
 ) {
+	logger = logger.With(zap.String("stage", "create-genesis-state"))
 	genesis := config.GetGenesis()
 	if genesis == nil {
-		panic("genesis is nil")
+		logger.Panic("genesis is nil")
 	}
 
 	seed, err := hex.DecodeString(engineConfig.GenesisSeed)
 	if err != nil {
-		panic(err)
+		logger.Panic("failed to decode genesis seed", zap.Error(err))
 	}
 
 	logger.Info("creating genesis frame from message:")
@@ -558,32 +559,32 @@ func CreateGenesisState(
 
 		err = json.Unmarshal(bridgedPeersJsonBinary, &bridged)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to unmarshal bridged peers json", zap.Error(err))
 		}
 
 		err = json.Unmarshal(ceremonyVouchersJsonBinary, &vouchers)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to unmarshal ceremony vouchers json", zap.Error(err))
 		}
 
 		err = json.Unmarshal(firstRetroJsonBinary, &firstRetro)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to unmarshal first retro json", zap.Error(err))
 		}
 
 		err = json.Unmarshal(secondRetroJsonBinary, &secondRetro)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to unmarshal second retro json", zap.Error(err))
 		}
 
 		err = json.Unmarshal(thirdRetroJsonBinary, &thirdRetro)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to unmarshal third retro json", zap.Error(err))
 		}
 
 		err = json.Unmarshal(fourthRetroJsonBinary, &fourthRetro)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to unmarshal fourth retro json", zap.Error(err))
 		}
 
 		bridgedAddrs := map[string]struct{}{}
@@ -593,7 +594,7 @@ func CreateGenesisState(
 		for _, b := range bridged {
 			amt, err := decimal.NewFromString(b.Amount)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to parse bridged amount", zap.Error(err))
 			}
 			bridgeTotal = bridgeTotal.Add(amt)
 			bridgedAddrs[b.Identifier] = struct{}{}
@@ -610,7 +611,7 @@ func CreateGenesisState(
 			if _, ok := bridgedAddrs[f.PeerId]; !ok {
 				peerIdTotals[f.PeerId], err = decimal.NewFromString(f.Reward)
 				if err != nil {
-					panic(err)
+					logger.Panic("failed to parse first retro amount", zap.Error(err))
 				}
 			}
 
@@ -618,7 +619,7 @@ func CreateGenesisState(
 			max := 157208
 			actual, err := strconv.Atoi(f.Reward)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to parse first retro amount", zap.Error(err))
 			}
 
 			peerSeniority[addrBytes] = uint64(10 * 6 * 60 * 24 * 92 / (max / actual))
@@ -642,7 +643,7 @@ func CreateGenesisState(
 
 				amount, err := decimal.NewFromString(f.Reward)
 				if err != nil {
-					panic(err)
+					logger.Panic("failed to parse second retro amount", zap.Error(err))
 				}
 
 				if !ok {
@@ -687,7 +688,7 @@ func CreateGenesisState(
 
 			amount, err := decimal.NewFromString(f.Reward)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to parse third retro amount", zap.Error(err))
 			}
 
 			if !ok {
@@ -713,7 +714,7 @@ func CreateGenesisState(
 
 			amount, err := decimal.NewFromString(f.Reward)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to parse fourth retro amount", zap.Error(err))
 			}
 
 			if !ok {
@@ -736,7 +737,7 @@ func CreateGenesisState(
 		factor, _ := decimal.NewFromString("8000000000")
 		bridgeAddressHex, err := hex.DecodeString(BridgeAddress)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to decode bridge address", zap.Error(err))
 		}
 
 		totalExecutions := 0
@@ -778,12 +779,12 @@ func CreateGenesisState(
 			}
 			peerBytes, err := base58.Decode(peerId)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to decode peer id", zap.Error(err))
 			}
 
 			addr, err := poseidon.HashBytes(peerBytes)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to hash peer id", zap.Error(err))
 			}
 
 			genesisState.Outputs = append(genesisState.Outputs, &protobufs.TokenOutput{
@@ -818,12 +819,12 @@ func CreateGenesisState(
 			}
 			keyBytes, err := hex.DecodeString(voucher[2:])
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to decode voucher", zap.Error(err))
 			}
 
 			addr, err := poseidon.HashBytes(keyBytes)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to hash voucher", zap.Error(err))
 			}
 
 			genesisState.Outputs = append(genesisState.Outputs, &protobufs.TokenOutput{
@@ -856,12 +857,12 @@ func CreateGenesisState(
 		txn, err := coinStore.NewTransaction(false)
 		for _, output := range genesisState.Outputs {
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to create transaction", zap.Error(err))
 			}
 
 			address, err := GetAddressOfCoin(output.GetCoin(), 0, 0)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to get address of coin", zap.Error(err))
 			}
 			err = coinStore.PutCoin(
 				txn,
@@ -870,7 +871,7 @@ func CreateGenesisState(
 				output.GetCoin(),
 			)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to put coin", zap.Error(err))
 			}
 
 			value := []byte{}
@@ -901,7 +902,7 @@ func CreateGenesisState(
 			)
 			if err != nil {
 				txn.Abort()
-				panic(err)
+				logger.Panic("failed to commit and save vertex data", zap.Error(err))
 			}
 
 			if err := hg.AddVertex(
@@ -914,16 +915,16 @@ func CreateGenesisState(
 				),
 			); err != nil {
 				txn.Abort()
-				panic(err)
+				logger.Panic("failed to add vertex", zap.Error(err))
 			}
 		}
 		if err := txn.Commit(); err != nil {
-			panic(err)
+			logger.Panic("failed to commit transaction", zap.Error(err))
 		}
 
 		txn, err = clockStore.NewTransaction(false)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to create transaction", zap.Error(err))
 		}
 
 		err = clockStore.PutPeerSeniorityMap(
@@ -932,20 +933,20 @@ func CreateGenesisState(
 			map[string]uint64{},
 		)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to put peer seniority map", zap.Error(err))
 		}
 
 		intrinsicFilter := p2p.GetBloomFilter(application.TOKEN_ADDRESS, 256, 3)
 
 		if err = txn.Commit(); err != nil {
-			panic(err)
+			logger.Panic("failed to commit transaction", zap.Error(err))
 		}
 
 		logger.Info("encoded transcript")
 
 		outputBytes, err := proto.Marshal(genesisState)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to marshal genesis state", zap.Error(err))
 		}
 
 		executionOutput := &protobufs.IntrinsicExecutionOutput{
@@ -956,20 +957,20 @@ func CreateGenesisState(
 
 		data, err := proto.Marshal(executionOutput)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to marshal execution output", zap.Error(err))
 		}
 
 		logger.Debug("encoded execution output")
 		digest := sha3.NewShake256()
 		_, err = digest.Write(data)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to write digest", zap.Error(err))
 		}
 
 		expand := make([]byte, 1024)
 		_, err = digest.Read(expand)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to read digest", zap.Error(err))
 		}
 
 		commitment, err := inclusionProver.CommitRaw(
@@ -977,7 +978,7 @@ func CreateGenesisState(
 			16,
 		)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to commit raw", zap.Error(err))
 		}
 
 		logger.Debug("creating kzg proof")
@@ -987,7 +988,7 @@ func CreateGenesisState(
 			16,
 		)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to prove raw", zap.Error(err))
 		}
 
 		logger.Info("finalizing execution proof")
@@ -1014,7 +1015,7 @@ func CreateGenesisState(
 
 		addr, err := poseidon.HashBytes(genesis.Beacon)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to hash beacon", zap.Error(err))
 		}
 
 		factor, _ := new(big.Int).SetString("8000000000", 10)
@@ -1041,12 +1042,12 @@ func CreateGenesisState(
 		txn, err := coinStore.NewTransaction(false)
 		for _, output := range genesisState.Outputs {
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to create transaction", zap.Error(err))
 			}
 
 			address, err := GetAddressOfCoin(output.GetCoin(), 0, 0)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to get address of coin", zap.Error(err))
 			}
 			err = coinStore.PutCoin(
 				txn,
@@ -1055,11 +1056,11 @@ func CreateGenesisState(
 				output.GetCoin(),
 			)
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to put coin", zap.Error(err))
 			}
 			coinBytes, err := proto.Marshal(output.GetCoin())
 			if err != nil {
-				panic(err)
+				logger.Panic("failed to marshal coin", zap.Error(err))
 			}
 
 			data := []byte{}
@@ -1080,7 +1081,7 @@ func CreateGenesisState(
 			)
 			if err != nil {
 				txn.Abort()
-				panic(err)
+				logger.Panic("failed to commit and save vertex data", zap.Error(err))
 			}
 
 			if err := hg.AddVertex(
@@ -1093,20 +1094,20 @@ func CreateGenesisState(
 				),
 			); err != nil {
 				txn.Abort()
-				panic(err)
+				logger.Panic("failed to add vertex", zap.Error(err))
 			}
 		}
 		intrinsicFilter := p2p.GetBloomFilter(application.TOKEN_ADDRESS, 256, 3)
 
 		if err := txn.Commit(); err != nil {
-			panic(err)
+			logger.Panic("failed to commit transaction", zap.Error(err))
 		}
 
 		logger.Info("encoded transcript")
 
 		outputBytes, err := proto.Marshal(genesisState)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to marshal genesis state", zap.Error(err))
 		}
 
 		executionOutput := &protobufs.IntrinsicExecutionOutput{
@@ -1117,20 +1118,20 @@ func CreateGenesisState(
 
 		data, err := proto.Marshal(executionOutput)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to marshal execution output", zap.Error(err))
 		}
 
 		logger.Debug("encoded execution output")
 		digest := sha3.NewShake256()
 		_, err = digest.Write(data)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to write digest", zap.Error(err))
 		}
 
 		expand := make([]byte, 1024)
 		_, err = digest.Read(expand)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to read digest", zap.Error(err))
 		}
 
 		commitment, err := inclusionProver.CommitRaw(
@@ -1138,7 +1139,7 @@ func CreateGenesisState(
 			16,
 		)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to commit raw", zap.Error(err))
 		}
 
 		logger.Debug("creating kzg proof")
@@ -1148,7 +1149,7 @@ func CreateGenesisState(
 			16,
 		)
 		if err != nil {
-			panic(err)
+			logger.Panic("failed to prove raw", zap.Error(err))
 		}
 
 		logger.Info("finalizing execution proof")

--- a/node/internal/runtime/runtime.go
+++ b/node/internal/runtime/runtime.go
@@ -1,6 +1,10 @@
 package runtime
 
-import "runtime"
+import (
+	"runtime"
+
+	"source.quilibrium.com/quilibrium/monorepo/node/utils"
+)
 
 const minimumCores = 3
 
@@ -8,13 +12,14 @@ const minimumCores = 3
 // It will use GOMAXPROCS as a base, and then subtract a number of CPUs
 // which are meant to be left for other tasks, such as networking.
 func WorkerCount(requested int, validate bool) int {
+	logger := utils.GetLogger()
 	n := runtime.GOMAXPROCS(0)
 	if validate {
 		if n < minimumCores {
-			panic("invalid system configuration, must have at least 3 cores")
+			logger.Panic("invalid system configuration, must have at least 3 cores")
 		}
 		if requested > 0 && requested < minimumCores {
-			panic("invalid worker count, must have at least 3 workers")
+			logger.Panic("invalid worker count, must have at least 3 workers")
 		}
 	}
 	if requested > 0 {

--- a/node/keys/file.go
+++ b/node/keys/file.go
@@ -33,12 +33,12 @@ func NewFileKeyManager(
 	logger *zap.Logger,
 ) *FileKeyManager {
 	if keyStoreConfig.KeyStoreFile == nil {
-		panic("key store config missing")
+		logger.Panic("key store config missing")
 	}
 
 	key, err := hex.DecodeString(keyStoreConfig.KeyStoreFile.EncryptionKey)
 	if err != nil {
-		panic(err)
+		logger.Panic("could not decode encryption key", zap.Error(err))
 	}
 
 	store := make(map[string]Key)
@@ -55,7 +55,7 @@ func NewFileKeyManager(
 		os.FileMode(0600),
 	)
 	if err != nil {
-		panic(err)
+		logger.Panic("could not open store", zap.Error(err))
 	}
 
 	defer file.Close()
@@ -63,7 +63,7 @@ func NewFileKeyManager(
 	d := yaml.NewDecoder(file)
 
 	if err := d.Decode(store); err != nil {
-		panic(err)
+		logger.Panic("could not decode store", zap.Error(err))
 	}
 
 	return &FileKeyManager{

--- a/node/p2p/bloom_utils.go
+++ b/node/p2p/bloom_utils.go
@@ -4,7 +4,9 @@ import (
 	"math/big"
 	"sort"
 
+	"go.uber.org/zap"
 	"golang.org/x/crypto/sha3"
+	"source.quilibrium.com/quilibrium/monorepo/node/utils"
 )
 
 func GetOnesIndices(input []byte) []int {
@@ -47,17 +49,18 @@ func GetBloomFilter(data []byte, bitLength int, k int) []byte {
 // GetBloomFilterIndices returns the indices of a bloom filter, in increasing
 // order, assuming bitLength is a multiple of 32 as in GetBloomFilter.
 func GetBloomFilterIndices(data []byte, bitLength int, k int) []byte {
+	logger := utils.GetLogger().With(zap.String("stage", "get-bloom-filter-indices"))
 	size := big.NewInt(int64(bitLength)).BitLen() - 1
 	h := sha3.NewShake256()
 	_, err := h.Write(data)
 	if err != nil {
-		panic(err)
+		logger.Panic("could not write to hash", zap.Error(err))
 	}
 
 	digest := make([]byte, size*k)
 	_, err = h.Read(digest)
 	if err != nil {
-		panic(err)
+		logger.Panic("could not read from hash", zap.Error(err))
 	}
 
 	indices := []string{}

--- a/node/rpc/data_worker_ipc_server.go
+++ b/node/rpc/data_worker_ipc_server.go
@@ -97,19 +97,19 @@ func NewDataWorkerIPCServer(
 ) (*DataWorkerIPCServer, error) {
 	peerPrivKey, err := hex.DecodeString(config.P2P.PeerPrivKey)
 	if err != nil {
-		panic(errors.Wrap(err, "error unmarshaling peerkey"))
+		logger.Panic("error decoding peerkey", zap.Error(err))
 	}
 
 	privKey, err := pcrypto.UnmarshalEd448PrivateKey(peerPrivKey)
 	if err != nil {
-		panic(errors.Wrap(err, "error unmarshaling peerkey"))
+		logger.Panic("error unmarshaling peerkey", zap.Error(err))
 	}
 
 	pub := privKey.GetPublic()
 
 	pubKey, err := pub.Raw()
 	if err != nil {
-		panic(err)
+		logger.Panic("error getting public key", zap.Error(err))
 	}
 
 	digest := make([]byte, 128)
@@ -117,7 +117,7 @@ func NewDataWorkerIPCServer(
 	s.Write([]byte(pubKey))
 	_, err = s.Read(digest)
 	if err != nil {
-		panic(err)
+		logger.Panic("error reading digest", zap.Error(err))
 	}
 
 	indices := p2p.GetOnesIndices(p2p.GetBloomFilter(digest, 1024, 64))
@@ -159,8 +159,7 @@ func (r *DataWorkerIPCServer) Start() error {
 		zap.String("address", r.listenAddrGRPC),
 	)
 	if err := s.Serve(mn.NetListener(lis)); err != nil {
-		r.logger.Error("terminating server", zap.Error(err))
-		panic(err)
+		r.logger.Panic("terminating server", zap.Error(err))
 	}
 
 	return nil

--- a/node/rpc/node_rpc_server.go
+++ b/node/rpc/node_rpc_server.go
@@ -324,12 +324,12 @@ func (r *RPCServer) GetTokenInfo(
 		peerBytes := r.pubSub.GetPeerID()
 		peerAddr, err := poseidon.HashBytes(peerBytes)
 		if err != nil {
-			panic(err)
+			r.logger.Panic("failed to hash peer id", zap.Error(err))
 		}
 
 		addr, err := poseidon.HashBytes(provingKey.PublicKey)
 		if err != nil {
-			panic(err)
+			r.logger.Panic("failed to hash proving key", zap.Error(err))
 		}
 
 		addrBytes := addr.FillBytes(make([]byte, 32))
@@ -337,12 +337,12 @@ func (r *RPCServer) GetTokenInfo(
 
 		_, _, coins, err := r.coinStore.GetCoinsForOwner(addrBytes)
 		if err != nil {
-			panic(err)
+			r.logger.Panic("failed to get coins for owner", zap.Error(err))
 		}
 
 		_, _, otherCoins, err := r.coinStore.GetCoinsForOwner(peerAddrBytes)
 		if err != nil {
-			panic(err)
+			r.logger.Panic("failed to get coins for owner", zap.Error(err))
 		}
 
 		total := big.NewInt(0)

--- a/node/store/clock.go
+++ b/node/store/clock.go
@@ -1287,7 +1287,7 @@ func (p *PebbleClockStore) Compact(
 
 				selector, err := frame.GetSelector()
 				if err != nil {
-					panic(err)
+					p.logger.Panic("failed to get selector from frame", zap.Error(err))
 				}
 
 				parents = append(parents,
@@ -1302,7 +1302,7 @@ func (p *PebbleClockStore) Compact(
 
 				selector, err := frame.GetSelector()
 				if err != nil {
-					panic(err)
+					p.logger.Panic("failed to get selector from frame", zap.Error(err))
 				}
 
 				err = p.db.Set(

--- a/node/store/hypergraph.go
+++ b/node/store/hypergraph.go
@@ -17,6 +17,7 @@ import (
 	"source.quilibrium.com/quilibrium/monorepo/node/config"
 	"source.quilibrium.com/quilibrium/monorepo/node/crypto"
 	"source.quilibrium.com/quilibrium/monorepo/node/hypergraph/application"
+	"source.quilibrium.com/quilibrium/monorepo/node/utils"
 )
 
 type HypergraphStore interface {
@@ -1118,7 +1119,7 @@ func (p *PebbleHypergraphStore) GetNodeByPath(
 func generateSlices(fullpref, pref []int) [][]int {
 	result := [][]int{}
 	if len(pref) > len(fullpref) {
-		panic("invalid prefix length")
+		utils.GetLogger().Panic("invalid prefix length")
 	}
 	for i := len(pref); i <= len(fullpref); i++ {
 		newSlice := make([]int, i)

--- a/node/store/pebble.go
+++ b/node/store/pebble.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/cockroachdb/pebble"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"source.quilibrium.com/quilibrium/monorepo/node/config"
+	"source.quilibrium.com/quilibrium/monorepo/node/utils"
 )
 
 type PebbleDB struct {
@@ -22,7 +24,7 @@ func NewPebbleDB(config *config.DBConfig) *PebbleDB {
 	}
 	db, err := pebble.Open(config.Path, opts)
 	if err != nil {
-		panic(err)
+		utils.GetLogger().Panic("failed to open pebble db", zap.Error(err))
 	}
 
 	return &PebbleDB{db}

--- a/node/utils/logging.go
+++ b/node/utils/logging.go
@@ -1,0 +1,24 @@
+package utils
+
+import "go.uber.org/zap"
+
+var logger *zap.Logger
+var debugLogger *zap.Logger
+
+func GetLogger() *zap.Logger {
+	return logger
+}
+
+func GetDebugLogger() *zap.Logger {
+	return debugLogger
+}
+
+func init() {
+	config := zap.NewProductionConfig()
+	config.DisableCaller = false
+	config.DisableStacktrace = false
+	logger = zap.Must(config.Build())
+
+	debugConfig := zap.NewDevelopmentConfig()
+	debugLogger = zap.Must(debugConfig.Build())
+}

--- a/node/utils/selftest_intrinsics_unix.go
+++ b/node/utils/selftest_intrinsics_unix.go
@@ -3,14 +3,17 @@
 
 package utils
 
-import "golang.org/x/sys/unix"
+import (
+	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+)
 
 func GetDiskSpace(dir string) uint64 {
 	var stat unix.Statfs_t
 
 	err := unix.Statfs(dir, &stat)
 	if err != nil {
-		panic(err)
+		GetLogger().Panic("failed statfs", zap.Error(err))
 	}
 
 	return stat.Bavail * uint64(stat.Bsize)

--- a/node/utils/selftest_intrinsics_windows.go
+++ b/node/utils/selftest_intrinsics_windows.go
@@ -3,7 +3,10 @@
 
 package utils
 
-import "golang.org/x/sys/windows"
+import (
+	"go.uber.org/zap"
+	"golang.org/x/sys/windows"
+)
 
 func GetDiskSpace(dir string) uint64 {
 	var freeBytesAvailable uint64
@@ -13,7 +16,7 @@ func GetDiskSpace(dir string) uint64 {
 	err := windows.GetDiskFreeSpaceEx(windows.StringToUTF16Ptr(dir),
 		&freeBytesAvailable, &totalNumberOfBytes, &totalNumberOfFreeBytes)
 	if err != nil {
-		panic(err)
+		GetLogger().Panic("failed GetDiskFreeSpaceEx", zap.Error(err))
 	}
 
 	return totalNumberOfBytes


### PR DESCRIPTION
## What I Did
1. Defined the entire lifecycle into distinct phases
    - Added a stage field to every log entry using zap.Logger.
    - Enables quick identification of the operational phase when errors occur.

2. Replaced ad-hoc logging with structured logging, and migrated from native Go logging to zap.Logger with contextual fields:
    - fmt.Println → logger.Info()/Warn()
    - panic() → logger.Panic()
    - os.Exit(1) → logger.Fatal()
    - log.Printf/log.Fatalf → logger.Info()/logger.Fatal()

## What I Did Not Do
Preserved debug/visual-only outputs

Left untouched: Functions like printLogo() or printTree() in debugNode,
as they serve purely for human-readable visualization.