### PR TITLE
Respect config's  "logging" section params and remove obsolete "logFile" config parameter

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,6 @@ type Config struct {
 	Logger              *LogConfig    `yaml:"logger"`
 	ListenGRPCMultiaddr string        `yaml:"listenGrpcMultiaddr"`
 	ListenRestMultiaddr string        `yaml:"listenRESTMultiaddr"`
-	LogFile             string        `yaml:"logFile"`
 }
 
 // WithDefaults returns a copy of the config with default values filled in.

--- a/config/logger.go
+++ b/config/logger.go
@@ -21,18 +21,15 @@ func (c *Config) CreateLogger(coreId uint, debug bool) (
 	io.Closer,
 	error,
 ) {
-	filename := c.LogFile
-	if filename != "" || c.Logger != nil {
-		dir := ""
-		if c.Logger != nil {
-			dir = c.Logger.Path
-		}
-
+	if c.Logger != nil {
 		logger, closer, err := logging.NewRotatingFileLogger(
 			debug,
 			coreId,
-			dir,
-			filename,
+			c.Logger.Path,
+			c.Logger.MaxSize,
+			c.Logger.MaxBackups,
+			c.Logger.MaxAge,
+			c.Logger.Compress,
 		)
 		return logger, closer, errors.Wrap(err, "create logger")
 	}

--- a/utils/logging/file_logger.go
+++ b/utils/logging/file_logger.go
@@ -23,31 +23,29 @@ func NewRotatingFileLogger(
 	debug bool,
 	coreId uint,
 	dir string,
-	filename string,
+	maxSize int,
+	maxBackups int,
+	maxAge int,
+	compress bool,
 ) (
 	*zap.Logger,
 	io.Closer,
 	error,
 ) {
-	if dir == "" {
-		dir = "./logs"
-	}
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, nil, err
 	}
 
-	if filename == "" {
-		filename = filenameForCore(coreId)
-	}
+	filename := filenameForCore(coreId)
 
-	path := filepath.Join(dir, filename)
+	logFilePath := filepath.Join(dir, filename)
 
 	rot := &lumberjack.Logger{
-		Filename:   path,
-		MaxSize:    50,   // megabytes per file before rotation
-		MaxBackups: 5,    // number of old files to keep
-		MaxAge:     14,   // days
-		Compress:   true, // gzip old files
+		Filename:   logFilePath,
+		MaxSize:    maxSize,
+		MaxBackups: maxBackups,
+		MaxAge:     maxAge,
+		Compress:   compress,
 	}
 
 	encCfg := zap.NewProductionEncoderConfig()


### PR DESCRIPTION
1. Passes config 's **logging** section parameters to the file logger constructor
2. Removes obsolete single-file logging top-level config parameter