### PR TITLE
Default to Info log level unless debug is enabled

### DIFF
--- a/utils/logging/file_logger.go
+++ b/utils/logging/file_logger.go
@@ -59,7 +59,13 @@ func NewRotatingFileLogger(
 	enc := zapcore.NewConsoleEncoder(encCfg)
 
 	ws := zapcore.AddSync(rot)
-	core := zapcore.NewCore(enc, ws, zap.DebugLevel)
+
+	logLevel := zap.InfoLevel
+	if debug {
+		logLevel = zap.DebugLevel
+	}
+
+	core := zapcore.NewCore(enc, ws, logLevel)
 	logger := zap.New(core, zap.AddCaller(), zap.Fields(
 		zap.Uint("coreId", coreId),
 	))


### PR DESCRIPTION
Sets file logger's logging level to _Info_ unless **debug** parameter is enabled