### PR TITLE
Missing "keys.yml" re-creation fix

### DIFF
--- a/node/keys/file.go
+++ b/node/keys/file.go
@@ -73,10 +73,17 @@ func NewFileKeyManager(
 
 	defer file.Close()
 
-	d := yaml.NewDecoder(file)
+	fileInfo, err := file.Stat()
 
-	if err := d.Decode(store); err != nil {
-		logger.Panic("could not decode store", zap.Error(err))
+	if err != nil {
+		logger.Panic("could not get key file info", zap.Error(err))
+	}
+
+	if fileInfo.Size() != 0 {
+		d := yaml.NewDecoder(file)
+		if err := d.Decode(store); err != nil {
+			logger.Panic("could not decode store", zap.Error(err))
+		}
 	}
 
 	keyManager := &FileKeyManager{


### PR DESCRIPTION
If `key.keyManagerFile.createIfMissing` is set to `true` and the `keys.yml` file is missing, the node is expected to re-create it upon startup.
Currently, the node panics trying to decode YAML from empty file.
The fix skips the decoding if the `keys.yml` file size is zero (implying it is being re-created).