### PR TITLE
Print worker filter on start and skip respawn for empty filter loaded from store

### DIFF
--- a/node/datarpc/data_worker_ipc_server.go
+++ b/node/datarpc/data_worker_ipc_server.go
@@ -193,6 +193,7 @@ func (r *DataWorkerIPCServer) RespawnServer(filter []byte) error {
 		"data worker listening",
 		zap.String("address", r.listenAddrGRPC),
 		zap.String("resolved", lis.Addr().String()),
+		zap.ByteString("filter", filter),
 	)
 	if len(filter) != 0 {
 		globalTimeReel, err := r.appConsensusEngineFactory.CreateGlobalTimeReel()

--- a/node/worker/manager.go
+++ b/node/worker/manager.go
@@ -540,18 +540,21 @@ func (w *WorkerManager) loadWorkersFromStore() error {
 			allocatedCount++
 		}
 		totalStorage += uint64(worker.TotalStorage)
-		svc, err := w.getIPCOfWorker(worker.CoreId)
-		if err != nil {
-			w.logger.Error("could not obtain IPC for worker", zap.Error(err))
-			continue
-		}
 
-		_, err = svc.Respawn(w.ctx, &protobufs.RespawnRequest{
-			Filter: worker.Filter,
-		})
-		if err != nil {
-			w.logger.Error("could not respawn worker", zap.Error(err))
-			continue
+		if len(worker.Filter) > 0 {
+			svc, err := w.getIPCOfWorker(worker.CoreId)
+			if err != nil {
+				w.logger.Error("could not obtain IPC for worker", zap.Error(err))
+				continue
+			}
+
+			_, err = svc.Respawn(w.ctx, &protobufs.RespawnRequest{
+				Filter: worker.Filter,
+			})
+			if err != nil {
+				w.logger.Error("could not respawn worker", zap.Error(err))
+				continue
+			}
 		}
 	}
 


### PR DESCRIPTION
Worker Manager prints the following messages upon node start when trying to respawn worker after loading worker from store. 
```json
{"level":"error","ts":1761757093.1862228,"logger":"worker_manager","caller":"worker/manager.go:555","msg":"could not respawn worker","process":"master","error":"rpc error: code = Unavailable desc = connection error: desc = \"transport: Error while dialing: dial tcp 127.0.0.1:60000: connect: connection refused\"","stacktrace":"source.quilibrium.com/quilibrium/monorepo/node/worker.(*WorkerManager).loadWorkersFromStore\n\t/opt/ceremonyclient/node/worker/manager.go:555\nsource.quilibrium.com/quilibrium/monorepo/node/worker.(*WorkerManager).Start\n\t/opt/ceremonyclient/node/worker/manager.go:107\nsource.quilibrium.com/quilibrium/monorepo/node/consensus/global.(*GlobalConsensusEngine).Start\n\t/opt/ceremonyclient/node/consensus/global/global_consensus_engine.go:461\nsource.quilibrium.com/quilibrium/monorepo/node/app.(*MasterNode).Start\n\t/opt/ceremonyclient/node/app/node.go:87\nmain.main.func6\n\t/opt/ceremonyclient/node/main.go:561"}
```
The main motivation for the wotker respawn is setting non-empty filter that is used on worker start by default.
At the time of the check, the filters fetched from the store are empty, thus the worker respawn makes no sense.
The PR skip worker respawn if the worker loaded from store has empty filter and prints worker filter on its start to clarity.