### PR TITLE
Fix udp/quic p2p connectivity/reachability testing

### DIFF
--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -1422,7 +1422,7 @@ func (s *connectivityService) TestConnectivity(
 				continue
 			}
 			// Build UDP multiaddr with actual IP
-			newAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/udp/%s", host, port))
+			newAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/udp/%s/quic-v1", host, port))
 			if err != nil {
 				continue
 			}


### PR DESCRIPTION
Append `quic-v1` to UDP multiaddr to make it valid