### PR TITLE
Force TCP for stream multiaddr

### DIFF
--- a/node/main.go
+++ b/node/main.go
@@ -521,6 +521,13 @@ func main() {
 			rpcMultiaddr = nodeConfig.Engine.DataWorkerStreamMultiaddrs[*core-1]
 		}
 
+		rpcMultiaddr = strings.Replace(rpcMultiaddr, "/0.0.0.0/", "/127.0.0.1/", 1)
+		rpcMultiaddr = strings.Replace(rpcMultiaddr, "/0:0:0:0:0:0:0:0/", "/::1/", 1)
+		rpcMultiaddr = strings.Replace(rpcMultiaddr, "/::/", "/::1/", 1)
+		// force TCP as stream is not supported over UDP/QUIC
+		rpcMultiaddr = strings.Replace(rpcMultiaddr, "/quic-v1", "", 1)
+		rpcMultiaddr = strings.Replace(rpcMultiaddr, "udp", "tcp", 1)
+
 		dataWorkerNode, err := app.NewDataWorkerNode(
 			logger,
 			nodeConfig,

--- a/node/worker/manager.go
+++ b/node/worker/manager.go
@@ -817,6 +817,9 @@ func (w *WorkerManager) getMultiaddrOfWorker(coreId uint) (
 	rpcMultiaddr = strings.Replace(rpcMultiaddr, "/0.0.0.0/", "/127.0.0.1/", 1)
 	rpcMultiaddr = strings.Replace(rpcMultiaddr, "/0:0:0:0:0:0:0:0/", "/::1/", 1)
 	rpcMultiaddr = strings.Replace(rpcMultiaddr, "/::/", "/::1/", 1)
+	// force TCP as stream is not supported over UDP/QUIC
+	rpcMultiaddr = strings.Replace(rpcMultiaddr, "/quic-v1", "", 1)
+	rpcMultiaddr = strings.Replace(rpcMultiaddr, "udp", "tcp", 1)
 
 	ma, err := multiaddr.StringCast(rpcMultiaddr)
 	return ma, errors.Wrap(err, "get multiaddr of worker")


### PR DESCRIPTION
Ensures that when `engine.dataWorkerBaseListenMultiaddr` refers to UDP/QUIC, the derived stream multiaddrs revert to TCP, which is the only supported network for streaming