### PR TITLE
Feat/add auto re peering if no peers found

### DIFF
--- a/config/p2p.go
+++ b/config/p2p.go
@@ -18,6 +18,7 @@ const (
 	defaultPingTimeout              = 5 * time.Second
 	defaultPingPeriod               = 30 * time.Second
 	defaultPingAttempts             = 3
+	defaultPeerReconnectInterval    = 60 * time.Second
 	defaultStreamListenMultiaddr    = "/ip4/0.0.0.0/tcp/8340"
 )
 
@@ -76,6 +77,7 @@ type P2PConfig struct {
 	ValidateWorkers               int           `yaml:"validateWorkers"`
 	SubscriptionQueueSize         int           `yaml:"subscriptionQueueSize"`
 	PeerOutboundQueueSize         int           `yaml:"peerOutboundQueueSize"`
+	PeerReconnectCheckInterval    time.Duration `yaml:"peerReconnectCheckInterval"`
 }
 
 // WithDefaults returns a copy of the P2PConfig with any missing fields set to
@@ -219,6 +221,9 @@ func (c P2PConfig) WithDefaults() P2PConfig {
 	}
 	if cpy.PeerOutboundQueueSize == 0 {
 		cpy.PeerOutboundQueueSize = blossomsub.DefaultPeerOutboundQueueSize
+	}
+	if cpy.PeerReconnectCheckInterval == 0 {
+		cpy.PeerReconnectCheckInterval = defaultPeerReconnectInterval
 	}
 	return cpy
 }

--- a/node/p2p/blossomsub.go
+++ b/node/p2p/blossomsub.go
@@ -872,13 +872,42 @@ func (b *BlossomSub) background(ctx context.Context) {
 	refreshScores := time.NewTicker(DecayInterval)
 	defer refreshScores.Stop()
 
+	peerReconnectInterval := b.p2pConfig.PeerReconnectCheckInterval
+	peerReconnect := time.NewTicker(peerReconnectInterval)
+	defer peerReconnect.Stop()
+
 	for {
 		select {
 		case <-refreshScores.C:
 			b.refreshScores()
+		case <-peerReconnect.C:
+			b.checkAndReconnectPeers(ctx)
 		case <-ctx.Done():
 			return
 		}
+	}
+}
+
+func (b *BlossomSub) checkAndReconnectPeers(ctx context.Context) {
+	peerCount := len(b.h.Network().Peers())
+	if peerCount > 0 {
+		return
+	}
+
+	b.logger.Warn(
+		"no peers connected, attempting to re-bootstrap and discover",
+		zap.Duration("check_interval", b.p2pConfig.PeerReconnectCheckInterval),
+	)
+
+	if err := b.DiscoverPeers(ctx); err != nil {
+		b.logger.Error("peer reconnect failed", zap.Error(err))
+	}
+
+	newCount := len(b.h.Network().Peers())
+	if newCount > 0 {
+		b.logger.Info("peer reconnect succeeded", zap.Int("peers", newCount))
+	} else {
+		b.logger.Warn("peer reconnect: still no peers found, will retry at next interval")
 	}
 }
 


### PR DESCRIPTION
runs the `b.DiscoverPeers(ctx)` function again if peerCount is 0.  

The current workaround is to restart, but this will run automatically, by default, every 60 seconds, or modifiable by node config: 
```
p2p:
  peerReconnectCheckInterval: 300s  # 5 minutes, for example
```