### PR TITLE
fix quil-engine unit tests

### DIFF
--- a/crates/quil-engine/Cargo.toml
+++ b/crates/quil-engine/Cargo.toml
@@ -45,6 +45,7 @@ async-trait = "0.1"
 [dev-dependencies]
 quil-hypergraph = { path = "../quil-hypergraph", features = ["test-utils"] }
 quil-execution = { path = "../quil-execution", features = ["testing-stubs"] }
+quil-crypto = { path = "../quil-crypto", features = ["vdf-prover"] }
 bs58 = "0.5"
 parking_lot = "0.12"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/crates/quil-engine/src/message_router.rs
+++ b/crates/quil-engine/src/message_router.rs
@@ -538,8 +538,13 @@ mod tests {
         assert!(!outcome.should_dispatch());
     }
 
+    // 57 bytes of 0xBB pass the length gate but do not decode to a valid
+    // Ed448 point, so `PublicKey::from([u8; 57])` panics inside the
+    // validator (see `crates/ed448-rust/src/public_key.rs:167`). The
+    // router's `catch_unwind` turns that panic into `Rejected`, which is
+    // the observable contract we pin here.
     #[test]
-    fn router_validator_passes_well_formed_peer_info() {
+    fn router_validator_rejects_invalid_pubkey_point() {
         let r = MessageRouter::new();
         r.register_validator(
             bitmasks::GLOBAL_PEER_INFO.to_vec(),
@@ -556,6 +561,39 @@ mod tests {
         let pubkey = vec![0xBB; 57]; // 57 == Ed448 pubkey length
         let sig = vec![0xCC; 114];   // 114 == Ed448 signature length
         let bytes = quil_p2p::encode_canonical_peer_info(&info, &pubkey, &sig);
+
+        let outcome = r.route(bitmasks::GLOBAL_PEER_INFO, &bytes);
+        assert_eq!(outcome, RouteOutcome::Rejected);
+    }
+
+    #[test]
+    fn router_validator_passes_well_formed_peer_info() {
+        let r = MessageRouter::new();
+        r.register_validator(
+            bitmasks::GLOBAL_PEER_INFO.to_vec(),
+            validator_global_peer_info(),
+        );
+
+        let privkey = ed448_rust::PrivateKey::new(&mut rand::rngs::OsRng);
+        let pubkey_bytes = ed448_rust::PublicKey::from(&privkey).as_byte().to_vec();
+
+        let info = quil_p2p::CanonicalPeerInfo {
+            peer_id: vec![0xAA; 38],
+            timestamp: 1_700_000_000_000,
+            version: vec![2, 1, 0],
+            patch_number: vec![20],
+            ..Default::default()
+        };
+        // Sign the canonical encoding with the signature field cleared,
+        // matching what `validator_global_peer_info` reconstructs at
+        // verify-time (see signing_payload above). The validator passes
+        // `Some(&[])` as context, so we must sign with the same.
+        let signing_payload = quil_p2p::encode_canonical_peer_info(&info, &pubkey_bytes, &[]);
+        let sig = privkey
+            .sign(&signing_payload, Some(&[]))
+            .expect("sign must succeed")
+            .to_vec();
+        let bytes = quil_p2p::encode_canonical_peer_info(&info, &pubkey_bytes, &sig);
 
         let outcome = r.route(bitmasks::GLOBAL_PEER_INFO, &bytes);
         assert_eq!(outcome, RouteOutcome::Accepted, "well-formed PeerInfo must be accepted");

--- a/crates/quil-engine/tests/e2e_consensus.rs
+++ b/crates/quil-engine/tests/e2e_consensus.rs
@@ -53,6 +53,8 @@ fn build_test_exec_manager(
         inclusion_prover.clone(),
     ));
     let stubs = quil_execution::testing::NoopExecutionCrypto::new();
+    let hg_resolver: Arc<dyn quil_execution::hypergraph_intrinsic::HypergraphConfigResolver> =
+        Arc::new(quil_execution::testing::NoopHypergraphConfigResolver);
     quil_execution::ExecutionEngineManager::new(
         inclusion_prover,
         stubs.key_manager.clone(),
@@ -61,6 +63,7 @@ fn build_test_exec_manager(
         stubs.decaf_constructor,
         stubs.circuit_compiler,
         stubs.clock_store,
+        hg_resolver,
         include_global,
     )
 }
@@ -703,6 +706,7 @@ pub fn build_node(
         on_qc_observed: Some(qc_observed_hook),
         config_override: Some(cfg),
         genesis_qc_override: Some(genesis_qc),
+        kv_db: None,
     };
 
     let activation = quil_engine::consensus_activation::activate_consensus(params)
@@ -967,6 +971,7 @@ async fn single_archive_node_activates_consensus() {
         on_qc_observed: None,
         config_override: Some(cfg),
         genesis_qc_override: None,
+        kv_db: None,
     };
 
     let activation = quil_engine::consensus_activation::activate_consensus(params)
@@ -1836,6 +1841,8 @@ pub fn build_tier2_archive_rig_with_key_manager(
     //    tier-2 archive happy-path tests don't exercise the QUIL PoMW
     //    mint path or compute / token verify chains.
     let exec_stubs = quil_execution::testing::NoopExecutionCrypto::new();
+    let exec_hg_resolver: Arc<dyn quil_execution::hypergraph_intrinsic::HypergraphConfigResolver> =
+        Arc::new(quil_execution::testing::NoopHypergraphConfigResolver);
     let exec_manager = Arc::new(ExecutionEngineManager::new(
         inclusion_prover.clone(),
         exec_key_manager,
@@ -1844,6 +1851,7 @@ pub fn build_tier2_archive_rig_with_key_manager(
         exec_stubs.decaf_constructor,
         exec_stubs.circuit_compiler,
         exec_stubs.clock_store,
+        exec_hg_resolver,
         /* include_global */ true,
     ));
     // Wire frame-header deps so `invoke_frame_header` actually
@@ -1854,12 +1862,15 @@ pub fn build_tier2_archive_rig_with_key_manager(
         Arc::new(quil_engine::OptRewardIssuance);
     let bls_for_intrinsic: Arc<dyn quil_types::crypto::BlsConstructor> =
         Arc::new(quil_crypto::Bls48581KeyConstructor);
+    let frame_prover_for_intrinsic: Arc<dyn quil_types::crypto::FrameProver> =
+        Arc::new(StubFrameProver);
     exec_manager
         .install_global_frame_header_deps(
             prover_registry.clone() as Arc<dyn quil_types::consensus::ProverRegistry>,
             reward_issuer_for_intrinsic,
             bls_for_intrinsic,
             inclusion_prover.clone(),
+            frame_prover_for_intrinsic,
         )
         .expect("install_global_frame_header_deps");
 


### PR DESCRIPTION
Fix test compilation and failing unit tests in `quil-engine`. Note that `e2e_consensus` tests are still failing.