### PR TITLE
fix vdf link order and enable tests in CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -86,7 +86,6 @@ jobs:
       # 8 individually-named tests). Keep that list in one place rather
       # than splitting between YAML and config.
       - name: cargo nextest run --workspace
-        if: false # temporarily disabled due to test linking issue
         run: cargo nextest run --workspace --locked --no-fail-fast --exclude channelwasm --config-file .nextest.toml
 
   # ------------------------------------------------------------------

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,3 +78,42 @@ rpath = false
 lto   = true
 debug = false
 # panic = 'abort'
+
+# Test profile overrides.
+#
+# Cryptography tests are 10-100x slower in unoptimized builds because the
+# hand-rolled big-int, pairing, FFT, OT, and bulletproof code (and the
+# heavy third-party curve/hash crates) need inlining and const
+# propagation to be fast. The overrides below compile those packages
+# with optimizations when building tests; Swatinem/rust-cache caches
+# the resulting artifacts so the cost is paid once. Debug assertions
+# and overflow checks remain on. `cargo build`/`cargo check` are
+# unaffected — they use profile.dev.
+
+# All third-party dependencies. `*` matches every package except the
+# one currently being built, so workspace members still need explicit
+# overrides below.
+[profile.test.package."*"]
+opt-level = 3
+
+# Workspace crates whose own code is the hot path in tests.
+[profile.test.package.bls48581]
+opt-level = 3
+[profile.test.package.dkls23]
+opt-level = 3
+[profile.test.package.dkls23_ffi]
+opt-level = 3
+[profile.test.package.ed448-bulletproofs]
+opt-level = 3
+[profile.test.package.classgroup]
+opt-level = 3
+[profile.test.package.vdf]
+opt-level = 3
+[profile.test.package.ferret]
+opt-level = 3
+[profile.test.package.channel]
+opt-level = 3
+[profile.test.package.verenc]
+opt-level = 3
+[profile.test.package.rpm]
+opt-level = 3

--- a/crates/classgroup/build.rs
+++ b/crates/classgroup/build.rs
@@ -45,23 +45,15 @@ fn main() {
     // the macOS link falls back to dynamic and the binary needs
     // `libflint.dylib` at runtime.
     //
-    // Link order matters for static resolution: flint depends on gmp
-    // and mpfr, so those must come AFTER `-lflint` on the link line.
-    if target == "aarch64-apple-darwin" {
-        let flint_static_on_macos = env::var("FLINT_DIR").is_ok();
-        if flint_static_on_macos {
-            println!("cargo:rustc-link-lib=static=flint");
-        } else {
-            println!("cargo:rustc-link-lib=flint");
-        }
-        println!("cargo:rustc-link-lib=static=mpfr");
-        println!("cargo:rustc-link-lib=static=gmp");
-    } else {
-        println!("cargo:rustc-link-lib=static=flint");
-        println!("cargo:rustc-link-lib=mpfr");
-        println!("cargo:rustc-link-lib=static=gmp");
-    }
-
+    // Link order matters for static resolution: vdf depends on
+    // flint/gmp/mpfr, and flint depends on gmp/mpfr. With static
+    // archives, ld only extracts members whose exports satisfy
+    // currently-unresolved symbols, so the dependent archives must
+    // appear BEFORE the dependencies on the link line. cc's
+    // `compile("vdf")` emits `cargo:rustc-link-lib=static=vdf` at the
+    // time it's called — so we must call it BEFORE the flint/mpfr/gmp
+    // link-lib prints, otherwise libvdf ends up after libgmp on the
+    // link line and gmp members referenced only by vdf go unresolved.
     if target == "aarch64-apple-darwin" {
         // Resolve Homebrew install prefixes dynamically. The previous
         // hardcoded `/opt/homebrew/Cellar/gmp/6.3.0/lib`-style paths
@@ -91,6 +83,15 @@ fn main() {
             .flag(&inc_flint)
             .flag(&inc_mpfr)
             .compile("vdf");
+
+        let flint_static_on_macos = env::var("FLINT_DIR").is_ok();
+        if flint_static_on_macos {
+            println!("cargo:rustc-link-lib=static=flint");
+        } else {
+            println!("cargo:rustc-link-lib=flint");
+        }
+        println!("cargo:rustc-link-lib=static=mpfr");
+        println!("cargo:rustc-link-lib=static=gmp");
     } else if target == "aarch64-unknown-linux-gnu" {
         println!("cargo:rustc-link-search=native=/usr/local/lib");
         println!("cargo:rustc-link-search=native=/usr/lib/aarch64-linux-gnu/");
@@ -101,6 +102,9 @@ fn main() {
             .flag("-lflint")
             .flag("-lmpfr")
             .compile("vdf");
+        println!("cargo:rustc-link-lib=static=flint");
+        println!("cargo:rustc-link-lib=mpfr");
+        println!("cargo:rustc-link-lib=static=gmp");
     } else if target == "x86_64-unknown-linux-gnu" {
         // Ubuntu/Debian put apt's libgmp.a under the multiarch dir
         // (/usr/lib/x86_64-linux-gnu/), not directly in /usr/lib. Without
@@ -116,6 +120,9 @@ fn main() {
             .flag("-lflint")
             .flag("-lmpfr")
             .compile("vdf");
+        println!("cargo:rustc-link-lib=static=flint");
+        println!("cargo:rustc-link-lib=mpfr");
+        println!("cargo:rustc-link-lib=static=gmp");
     } else {
         panic!("unsupported target {target}");
     }


### PR DESCRIPTION
The `classgroup` crate failed to compile in test mode, this PR fixes that and unblocks enabling tests in the CI.

The issue was that `cargo test -p classgroup --no-run` failed at link time with dozens of `undefined reference to '__gmpz_*'` / `fmpz_*` errors against `libvdf.a` due to link directives being in the wrong order. This didn't show up in release builds probably because of release-mode inlining/dead code elimination.
