### PR TITLE
update Cargo.lock to fix ci

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4152,6 +4152,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
+ "sha3 0.10.8",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",


### PR DESCRIPTION
CI runs Cargo commands with the --locked flag for reproducibility + audibility. The Cargo.lock file needs an update after the last https://github.com/QuilibriumNetwork/monorepo/pull/529/commits/27cd8c5df638ee414185173b43ca42d630694c44 that added a new dep.