### PR TITLE
fix router_validator_passes_well_formed_peer_info test

### DIFF
--- a/crates/quil-engine/src/message_router.rs
+++ b/crates/quil-engine/src/message_router.rs
@@ -565,20 +565,24 @@ mod tests {
         let privkey = ed448_rust::PrivateKey::new(&mut rand::rngs::OsRng);
         let pubkey_bytes = ed448_rust::PublicKey::from(&privkey).as_byte().to_vec();
 
+        let now_ms = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as i64;
         let info = quil_p2p::CanonicalPeerInfo {
             peer_id: vec![0xAA; 38],
-            timestamp: 1_700_000_000_000,
+            timestamp: now_ms,
             version: vec![2, 1, 0],
             patch_number: vec![20],
             ..Default::default()
         };
         // Sign the canonical encoding with the signature field cleared,
         // matching what `validator_global_peer_info` reconstructs at
-        // verify-time (see signing_payload above). The validator passes
-        // `Some(&[])` as context, so we must sign with the same.
+        // verify-time. The validator uses pure Ed448 (context=None) to
+        // match Go's `ValidateSignature` with domain=[] context="".
         let signing_payload = quil_p2p::encode_canonical_peer_info(&info, &pubkey_bytes, &[]);
         let sig = privkey
-            .sign(&signing_payload, Some(&[]))
+            .sign(&signing_payload, None)
             .expect("sign must succeed")
             .to_vec();
         let bytes = quil_p2p::encode_canonical_peer_info(&info, &pubkey_bytes, &sig);


### PR DESCRIPTION
27cd8c5 added timestamp validation + changed the signature context which made `router_validator_passes_well_formed_peer_info` fail:

https://github.com/QuilibriumNetwork/monorepo/pull/529/changes/27cd8c5df638ee414185173b43ca42d630694c44#diff-8d0ee3148b2b18f66f3d3f2d82be8624bb8eba644f9d26155e9abbca8556d767R269

https://github.com/QuilibriumNetwork/monorepo/pull/529/changes/27cd8c5df638ee414185173b43ca42d630694c44#diff-8d0ee3148b2b18f66f3d3f2d82be8624bb8eba644f9d26155e9abbca8556d767R312