### PR TITLE
fix transaction safety for hypergraph store writes

### DIFF
--- a/.nextest.toml
+++ b/.nextest.toml
@@ -16,10 +16,6 @@ nextest-version = { required = "0.9.75" }
 # one long line.
 default-filter = """
     not (package(quil-engine) and binary(=e2e_consensus)) \
-and not (package(=quil-rpc) and binary(=send_signature_round_trip) and test(=ed448_sign_verify_over_canonical_bundle_matches_send_handler)) \
-and not (package(=quil-rpc) and binary(=send_signature_round_trip) and test(=ed448_simple_round_trip)) \
-and not (package(=quil-rpc) and binary(=vertex_data_end_to_end) and test(=get_hyperedge_data_returns_known_indices)) \
-and not (package(=quil-rpc) and binary(=vertex_data_end_to_end) and test(=get_vertex_data_round_trips_inserted_leaves)) \
 """
 
 # Per-skip notes (kept here so they don't bloat the filter expression).
@@ -27,12 +23,3 @@ and not (package(=quil-rpc) and binary(=vertex_data_end_to_end) and test(=get_ve
 # quil-engine::e2e_consensus (whole binary)
 #   Tier-1 in-process multi-node consensus tests — archive ↔ non-archive
 #   HotStuff + app-shard flow currently fails. Mid-stabilization.
-#
-# quil-rpc::send_signature_round_trip::ed448_simple_round_trip
-# quil-rpc::send_signature_round_trip::ed448_sign_verify_over_canonical_bundle_matches_send_handler
-#   ed448 round-trip integration tests fail — likely the same root cause
-#   as the ed448-rust unit tests above.
-#
-# quil-rpc::vertex_data_end_to_end::get_hyperedge_data_returns_known_indices
-# quil-rpc::vertex_data_end_to_end::get_vertex_data_round_trips_inserted_leaves
-#   Vertex/hyperedge end-to-end integration tests fail.

--- a/crates/quil-engine/src/shard_info.rs
+++ b/crates/quil-engine/src/shard_info.rs
@@ -1027,7 +1027,7 @@ mod tests {
         fn load_vertex_underlying_raw(&self, set: &str, phase: &str, shard: &TypedShardKey, k: &[u8]) -> QResult<Option<Vec<u8>>> {
             Ok(self.nodes.lock().unwrap().get(&Self::key(set, phase, shard, k)).cloned())
         }
-        fn save_vertex_underlying(&self, set: &str, phase: &str, shard: &TypedShardKey, k: &[u8], d: &[u8]) -> QResult<()> {
+        fn save_vertex_underlying(&self, _txn: &dyn quil_types::store::Transaction, set: &str, phase: &str, shard: &TypedShardKey, k: &[u8], d: &[u8]) -> QResult<()> {
             self.nodes.lock().unwrap().insert(Self::key(set, phase, shard, k), d.to_vec());
             self.per_vertex.lock().unwrap().insert((Self::scope(set, phase, shard), k.to_vec()), d.to_vec());
             Ok(())

--- a/crates/quil-execution/Cargo.toml
+++ b/crates/quil-execution/Cargo.toml
@@ -38,6 +38,7 @@ serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"
+quil-store = { path = "../quil-store", features = ["test-utils"] }
 quil-hypergraph = { path = "../quil-hypergraph", features = ["test-utils"] }
 quil-crypto = { path = "../quil-crypto", features = ["vdf-prover"] }
 quil-engine = { path = "../quil-engine" }

--- a/crates/quil-execution/src/hypergraph_state.rs
+++ b/crates/quil-execution/src/hypergraph_state.rs
@@ -476,7 +476,7 @@ impl quil_types::store::HypergraphStore for InMemoryHypergraphStore {
     fn load_vertex_underlying_raw(&self, s: &str, p: &str, sk: &quil_types::store::ShardKey, k: &[u8]) -> Result<Option<Vec<u8>>> {
         Ok(self.nodes.lock().unwrap().get(&Self::key(s, p, sk, k)).cloned())
     }
-    fn save_vertex_underlying(&self, s: &str, p: &str, sk: &quil_types::store::ShardKey, k: &[u8], d: &[u8]) -> Result<()> {
+    fn save_vertex_underlying(&self, _txn: &dyn quil_types::store::Transaction, s: &str, p: &str, sk: &quil_types::store::ShardKey, k: &[u8], d: &[u8]) -> Result<()> {
         self.nodes.lock().unwrap().insert(Self::key(s, p, sk, k), d.to_vec());
         self.per_vertex.lock().unwrap().insert((Self::scope(s, p, sk), k.to_vec()), d.to_vec());
         Ok(())

--- a/crates/quil-hypergraph/src/crdt.rs
+++ b/crates/quil-hypergraph/src/crdt.rs
@@ -609,11 +609,6 @@ impl HypergraphCrdt {
     /// to `commit()` — reads from the in-memory tree without writing
     /// anything to the store. Returns an empty vec if the shard/phase
     /// has no tree loaded.
-    /// Compute the current root commitment for a single phase set
-    /// (e.g. vertex-adds) of a single shard. Lightweight alternative
-    /// to `commit()` — reads from the in-memory tree without writing
-    /// to RocksDB. Returns an empty vec if the shard/phase has no
-    /// tree loaded.
     pub fn compute_shard_root(
         &self,
         set_type: &str,
@@ -631,23 +626,10 @@ impl HypergraphCrdt {
         let Some(t) = tree else {
             return Vec::new();
         };
-        // Use a no-op transaction — we only want the in-memory
-        // commitment, not a store write. `commit` loads the root
-        // if needed, walks dirty nodes, and returns the root hash.
-        struct NoopTxn;
-        impl quil_types::store::Transaction for NoopTxn {
-            fn get(&self, _: &[u8]) -> quil_types::error::Result<Option<Vec<u8>>> { Ok(None) }
-            fn set(&self, _: &[u8], _: &[u8]) -> quil_types::error::Result<()> { Ok(()) }
-            fn commit(self: Box<Self>) -> quil_types::error::Result<()> { Ok(()) }
-            fn delete(&self, _: &[u8]) -> quil_types::error::Result<()> { Ok(()) }
-            fn abort(self: Box<Self>) -> quil_types::error::Result<()> { Ok(()) }
-            fn new_iter(&self, _: &[u8], _: &[u8]) -> quil_types::error::Result<Box<dyn quil_types::store::Iterator>> {
-                Err(quil_types::error::QuilError::Internal("noop".into()))
-            }
-            fn delete_range(&self, _: &[u8], _: &[u8]) -> quil_types::error::Result<()> { Ok(()) }
-            fn as_any(&self) -> &dyn std::any::Any { self }
-        }
-        t.commit(&NoopTxn, self.prover.as_ref()).unwrap_or_default()
+        // Read-only root computation: recomputes commitments in memory
+        // and returns the root hash without writing to the store or
+        // touching the tree's dirty bookkeeping.
+        t.compute_root(self.prover.as_ref()).unwrap_or_default()
     }
 
     /// Look up whether a vertex exists (in adds and not in removes).
@@ -794,6 +776,11 @@ impl HypergraphCrdt {
     #[cfg(test)]
     pub(crate) fn insert_shard_metadata_for_test(&self, key: ShardKey, meta: ShardMetadata) {
         self.shard_metadata.write().unwrap().insert(key, meta);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn vertex_adds_dirty_for_test(&self, key: &ShardKey) -> bool {
+        self.phase_sets.read().unwrap().vertex_adds.get(key).map(|t| t.is_dirty()).unwrap_or(false)
     }
 
     #[cfg(test)]
@@ -975,6 +962,32 @@ mod tests {
         crdt.add_vertex(&loc(0xAA, 0x01), b"shard-1").unwrap();
         crdt.add_vertex(&loc(0xBB, 0x01), b"shard-2").unwrap();
         assert_eq!(crdt.commit(1).unwrap().len(), 2);
+    }
+
+    #[test] fn compute_shard_root_is_read_only() {
+        let store = Arc::new(MemStore::new());
+        let crdt = HypergraphCrdt::new(store.clone(), Arc::new(HashingProver));
+        // app[0] = 0x01 (<= 0x3f, not all-zero) so bloom indices are computed.
+        let l = loc(0x01, 0x02);
+        crdt.add_vertex(&l, b"data").unwrap();
+        let sk = crate::addressing::shard_key_for_location(&l);
+
+        // Read-only root computation returns a real, non-empty root...
+        let root = crdt.compute_shard_root("vertex", "adds", &sk);
+        assert!(!root.is_empty(), "compute_shard_root should return a root");
+        assert_ne!(root, vec![0u8; 64]);
+
+        // ...but persists nothing and leaves the tree dirty (uncommitted).
+        assert_eq!(store.node_count(), 0, "compute_shard_root must not write tree nodes");
+        assert_eq!(store.per_vertex_count(), 0, "compute_shard_root must not write vertex underlying data");
+        assert!(crdt.vertex_adds_dirty_for_test(&sk), "tree should still be dirty after a read-only root computation");
+
+        // The read-only path agrees byte-for-byte with what a real commit produces,
+        // and the real commit *does* persist.
+        let committed = crdt.commit(1).unwrap();
+        assert_eq!(committed.get(&sk).unwrap()[0], root,
+            "compute_shard_root must equal the committed vertex-adds root");
+        assert!(store.node_count() > 0, "commit should persist tree nodes");
     }
 
     #[test] fn vertex_and_hyperedge_in_same_shard_both_committed() {

--- a/crates/quil-hypergraph/src/crdt.rs
+++ b/crates/quil-hypergraph/src/crdt.rs
@@ -481,6 +481,13 @@ impl HypergraphCrdt {
 
         let empty_root = vec![0u8; 64];
         let mut result: HashMap<ShardKey, Vec<Vec<u8>>> = HashMap::new();
+        // Trees whose writes we staged into `txn` this call. Their dirty
+        // bookkeeping is cleared only after `txn.commit()` succeeds, so a
+        // failed/aborted commit leaves them dirty for a safe retry. The
+        // borrows are valid for the whole function: `sets` (the
+        // write-guard) is held until return, and nothing mutates a tree in
+        // between.
+        let mut committed_trees: Vec<&LazyVectorCommitmentTree> = Vec::new();
 
         // Phase tuple: (index into commits[shardKey], phase_type, set_type).
         // Indices match `hypergraph_shard_commit_key` layout in
@@ -523,6 +530,7 @@ impl HypergraphCrdt {
                 }
                 if let Some(tree) = phase_trees[i] {
                     let root = tree.commit(txn.as_ref(), prover)?;
+                    committed_trees.push(tree);
                     // Persist so a subsequent commit(frame_number)
                     // short-circuits on the idempotency check above.
                     self.store.set_shard_commit(
@@ -561,6 +569,14 @@ impl HypergraphCrdt {
         // impl that honors the txn argument (our `RocksTxn`) would
         // lose its buffered writes.
         txn.commit()?;
+
+        // The batch is now durable. Only now is it safe to clear each
+        // committed tree's dirty bookkeeping. If `txn.commit()` above had
+        // failed, the `?` would have returned early and left every tree
+        // dirty, so the next commit re-stages the writes that never landed.
+        for tree in committed_trees {
+            tree.mark_persisted();
+        }
 
         Ok(result)
     }

--- a/crates/quil-hypergraph/src/testing.rs
+++ b/crates/quil-hypergraph/src/testing.rs
@@ -102,7 +102,7 @@ impl HypergraphStore for MemStore {
         let k = Self::node_key(set, phase, shard, key);
         Ok(self.nodes.lock().unwrap().get(&k).cloned())
     }
-    fn save_vertex_underlying(&self, set: &str, phase: &str, shard: &ShardKey, key: &[u8], data: &[u8]) -> Result<()> {
+    fn save_vertex_underlying(&self, _txn: &dyn quil_types::store::Transaction, set: &str, phase: &str, shard: &ShardKey, key: &[u8], data: &[u8]) -> Result<()> {
         let k = Self::node_key(set, phase, shard, key);
         self.nodes.lock().unwrap().insert(k, data.to_vec());
         let scope = Self::vertex_scope(set, phase, shard);

--- a/crates/quil-hypergraph/src/testing.rs
+++ b/crates/quil-hypergraph/src/testing.rs
@@ -64,6 +64,16 @@ impl MemStore {
     fn vertex_scope(set: &str, phase: &str, shard: &ShardKey) -> String {
         format!("{}/{}/{:?}{:?}", set, phase, shard.l1, shard.l2)
     }
+
+    /// Number of tree nodes written to the store (test introspection).
+    pub fn node_count(&self) -> usize {
+        self.nodes.lock().unwrap().len()
+    }
+
+    /// Number of per-vertex underlying blobs written (test introspection).
+    pub fn per_vertex_count(&self) -> usize {
+        self.per_vertex.lock().unwrap().len()
+    }
 }
 
 impl HypergraphStore for MemStore {

--- a/crates/quil-rpc/Cargo.toml
+++ b/crates/quil-rpc/Cargo.toml
@@ -42,5 +42,6 @@ hyper = "1"
 
 [dev-dependencies]
 tempfile = "3"
+quil-store = { path = "../quil-store", features = ["test-utils"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/quil-rpc/src/hypergraph_sync_probe.rs
+++ b/crates/quil-rpc/src/hypergraph_sync_probe.rs
@@ -23,7 +23,7 @@ use quil_types::proto::application::{
     hypergraph_sync_query, hypergraph_sync_response, HypergraphPhaseSet,
     HypergraphSyncGetBranchRequest, HypergraphSyncGetLeavesRequest, HypergraphSyncQuery,
 };
-use quil_types::store::ShardKey;
+use quil_types::store::{HypergraphStore, ShardKey, Transaction};
 
 use crate::archive_client::{build_quil_client_config, QuilTlsConnector};
 
@@ -1039,22 +1039,52 @@ pub async fn ensure_shard_tree_fresh(
         }
     };
     let blob_size = serialized.len();
-    match hg_store.save_tree_blob(set_str, phase_str, shard, &serialized) {
-        Ok(()) => info!(?phase, blob_size, "shard tree refreshed"),
-        Err(e) => warn!(?phase, error = %e, "save_tree_blob failed"),
+    // Stage the tree blob and every per-vertex blob into a single
+    // transaction so the refresh is atomic: a crash or error partway
+    // through must not leave the tree blob and vertex data out of sync.
+    match persist_shard_refresh(
+        hg_store.as_ref(),
+        set_str,
+        phase_str,
+        shard,
+        &serialized,
+        &vertex_data,
+    ) {
+        Ok(persisted_vertices) => info!(
+            ?phase,
+            blob_size, persisted_vertices, "shard tree + per-vertex data refreshed"
+        ),
+        Err(e) => warn!(?phase, error = %e, "shard refresh persist failed, NOT persisted"),
     }
-
-    let mut persisted_vertices = 0usize;
-    for entry in &vertex_data {
-        if hg_store
-            .save_vertex_underlying(set_str, phase_str, shard, &entry.key, &entry.underlying_data)
-            .is_ok()
-        {
-            persisted_vertices += 1;
-        }
-    }
-    info!(?phase, persisted_vertices, "per-vertex data refreshed");
     Ok(stats)
+}
+
+/// Persist a shard tree blob and its per-vertex underlying blobs in one
+/// transaction. Either everything commits or (on error) nothing does —
+/// the txn is dropped, which aborts the batch. Returns the number of
+/// per-vertex blobs staged.
+fn persist_shard_refresh(
+    hg_store: &RocksHypergraphStore,
+    set_str: &str,
+    phase_str: &str,
+    shard: &ShardKey,
+    serialized: &[u8],
+    vertex_data: &[VertexDataEntry],
+) -> Result<usize, quil_types::error::QuilError> {
+    let txn = hg_store.new_transaction(false)?;
+    hg_store.save_tree_blob_txn(txn.as_ref(), set_str, phase_str, shard, serialized)?;
+    for entry in vertex_data {
+        hg_store.save_vertex_underlying_txn(
+            txn.as_ref(),
+            set_str,
+            phase_str,
+            shard,
+            &entry.key,
+            &entry.underlying_data,
+        )?;
+    }
+    txn.commit()?;
+    Ok(vertex_data.len())
 }
 
 /// Incremental prover tree sync. Loads the cached tree, compares its root
@@ -1377,20 +1407,20 @@ pub async fn ensure_prover_tree_incremental(
         }
     };
     let blob_size = serialized.len();
-    match hg_store.save_tree_blob(set_str, phase_str, &shard, &serialized) {
-        Ok(()) => info!(?phase, blob_size, "prover tree updated incrementally"),
-        Err(e) => warn!(?phase, error = %e, "save_tree_blob failed"),
+    // Atomic persist: tree blob + per-vertex blobs in one transaction.
+    match persist_shard_refresh(
+        hg_store.as_ref(),
+        set_str,
+        phase_str,
+        &shard,
+        &serialized,
+        &vertex_data,
+    ) {
+        Ok(persisted_vertices) => info!(
+            ?phase,
+            blob_size, persisted_vertices, "prover tree + per-vertex data updated incrementally"
+        ),
+        Err(e) => warn!(?phase, error = %e, "incremental persist failed, NOT persisted"),
     }
-
-    let mut persisted_vertices = 0usize;
-    for entry in &vertex_data {
-        if hg_store
-            .save_vertex_underlying(set_str, phase_str, &shard, &entry.key, &entry.underlying_data)
-            .is_ok()
-        {
-            persisted_vertices += 1;
-        }
-    }
-    info!(?phase, persisted_vertices, "per-vertex data updated incrementally");
     Ok(stats)
 }

--- a/crates/quil-rpc/tests/vertex_data_end_to_end.rs
+++ b/crates/quil-rpc/tests/vertex_data_end_to_end.rs
@@ -292,3 +292,93 @@ async fn get_vertex_data_round_trips_through_real_commit_path() {
         .into_inner();
     assert_eq!(resp_full.raw_data, serialized_tree);
 }
+
+#[tokio::test]
+async fn get_vertex_data_not_visible_when_commit_txn_aborted() {
+    // Transaction-fidelity regression test.
+    //
+    // `get_vertex_data_round_trips_through_real_commit_path` proves the
+    // *success* case: when the commit transaction is committed, the vertex
+    // underlying blob is visible to the handler. This test covers the
+    // *abort* case, which the success test cannot: when the surrounding
+    // transaction is aborted (or the process dies before commit), the
+    // vertex blob must NOT be durable.
+    //
+    // `LazyVectorCommitmentTree::commit` stages tree nodes into the txn via
+    // `insert_node`, but persists each leaf's underlying value through
+    // `walk_leaves_persist` → `save_vertex_underlying`. If that write
+    // bypasses the txn and goes straight to RocksDB, the blob survives an
+    // abort and `GetVertexData` serves data for a vertex whose tree/shard
+    // commit never landed. After the fix, the leaf write joins the same
+    // batch as the nodes, so aborting the txn discards everything.
+    let tmp = TempDir::new().unwrap();
+    let db = RocksDb::open(tmp.path()).unwrap();
+    let store = Arc::new(RocksHypergraphStore::new(Arc::new(db).inner()));
+
+    let mut address = vec![0u8; 64];
+    for (i, b) in address.iter_mut().enumerate().take(32) {
+        *b = 0x50 + i as u8;
+    }
+    let app_address = &address[..32];
+    let shard = ShardKey {
+        l1: quil_hypergraph::addressing::get_bloom_filter_indices(app_address, 256, 3),
+        l2: {
+            let mut l2 = [0u8; 32];
+            l2.copy_from_slice(app_address);
+            l2
+        },
+    };
+
+    let (serialized_tree, _leaves) = build_and_serialize();
+
+    // Drive the real commit path, but abort the transaction instead of
+    // committing it.
+    let lazy = LazyVectorCommitmentTree::new(
+        store.clone() as Arc<dyn HypergraphStore>,
+        "vertex",
+        "adds",
+        shard.clone(),
+        Vec::new(), // empty covered_prefix → no shard-range gate
+    );
+    lazy.insert(
+        &address,
+        &serialized_tree,
+        &[],
+        &BigInt::from(serialized_tree.len() as u64),
+    )
+    .unwrap();
+    let txn = store.new_transaction(false).unwrap();
+    let prover = KzgInclusionProver;
+    lazy.commit(txn.as_ref(), &prover).unwrap();
+    txn.abort().unwrap(); // drop without committing
+
+    let svc = NodeRpcServer::new()
+        .with_hypergraph_store(store.clone() as Arc<dyn HypergraphStore>);
+
+    // Nothing was committed, so the handler must see no vertex data.
+    let resp = svc
+        .get_vertex_data(Request::new(GetVertexDataRequest {
+            address: address.clone(),
+            full_data: false,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(
+        resp.entries.is_empty(),
+        "aborted commit must not leave enumerable vertex entries"
+    );
+
+    let resp_full = svc
+        .get_vertex_data(Request::new(GetVertexDataRequest {
+            address: address.clone(),
+            full_data: true,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(
+        resp_full.raw_data.is_empty(),
+        "aborted commit must not leave a durable vertex underlying blob"
+    );
+}

--- a/crates/quil-rpc/tests/vertex_data_end_to_end.rs
+++ b/crates/quil-rpc/tests/vertex_data_end_to_end.rs
@@ -254,6 +254,23 @@ async fn get_vertex_data_round_trips_through_real_commit_path() {
     lazy.commit(txn.as_ref(), &prover).unwrap();
     txn.commit().unwrap();
 
+    // Retry-safety lifecycle: `commit` only *stages* into the txn, so the
+    // tree still considers itself dirty even after `txn.commit()` — the
+    // dirty bookkeeping is cleared only by the explicit `mark_persisted`
+    // "the txn committed" signal (which is exactly what
+    // `HypergraphCRDT::commit` calls after its own `txn.commit()`). This
+    // assertion is red before the deferred-clear fix (commit cleared the
+    // flag itself) and green after.
+    assert!(
+        lazy.is_dirty(),
+        "tree must stay dirty until the caller signals durability via mark_persisted"
+    );
+    lazy.mark_persisted();
+    assert!(
+        !lazy.is_dirty(),
+        "mark_persisted after a confirmed commit must clear the dirty flag"
+    );
+
     let svc = NodeRpcServer::new()
         .with_hypergraph_store(store.clone() as Arc<dyn HypergraphStore>);
 
@@ -352,6 +369,15 @@ async fn get_vertex_data_not_visible_when_commit_txn_aborted() {
     lazy.commit(txn.as_ref(), &prover).unwrap();
     txn.abort().unwrap(); // drop without committing
 
+    // Retry-safety: an aborted commit must leave the tree dirty (no
+    // `mark_persisted` was called), so a later commit re-stages the writes
+    // that never landed. Before the deferred-clear fix, `commit` cleared
+    // the flag eagerly and the tree wrongly believed it had persisted.
+    assert!(
+        lazy.is_dirty(),
+        "an aborted commit must leave the tree dirty for a safe retry"
+    );
+
     let svc = NodeRpcServer::new()
         .with_hypergraph_store(store.clone() as Arc<dyn HypergraphStore>);
 
@@ -382,3 +408,4 @@ async fn get_vertex_data_not_visible_when_commit_txn_aborted() {
         "aborted commit must not leave a durable vertex underlying blob"
     );
 }
+

--- a/crates/quil-rpc/tests/vertex_data_end_to_end.rs
+++ b/crates/quil-rpc/tests/vertex_data_end_to_end.rs
@@ -19,7 +19,7 @@ use tonic::Request;
 use quil_crypto::KzgInclusionProver;
 use quil_rpc::node_service::NodeRpcServer;
 use quil_store::{RocksDb, RocksHypergraphStore};
-use quil_tries::{serialize_go_tree, VectorCommitmentTree};
+use quil_tries::{serialize_go_tree, LazyVectorCommitmentTree, VectorCommitmentTree};
 use quil_types::proto::node::{
     node_service_server::NodeService, GetHyperedgeDataRequest, GetVertexDataRequest,
 };
@@ -69,24 +69,14 @@ async fn get_vertex_data_round_trips_inserted_leaves() {
 
     let (serialized_tree, leaves) = build_and_serialize();
     // Persist the serialized sub-tree exactly the way Go's
-    // `hypergraph.SetVertexData` → `store.SaveVertexTree` does.
+    // `hypergraph.SetVertexData` → `store.SaveVertexTree` does, which the
+    // Rust side mirrors with `save_vertex_underlying`. The handler reads
+    // it back via `load_vertex_underlying_raw`, so the writer must use the
+    // matching per-vertex key scheme (not `insert_node`, which keys the
+    // global prover tree's individual nodes under a different prefix).
     store
-        .load_vertex_underlying_raw("vertex", "adds", &shard, &address)
-        .unwrap(); // absent lookup is fine
-    let txn = store.new_transaction(false).unwrap();
-    store
-        .insert_node(
-            txn.as_ref(),
-            "vertex",
-            "adds",
-            &shard,
-            &address,
-            &[],
-            &serialized_tree,
-        )
+        .save_vertex_underlying("vertex", "adds", &shard, &address, &serialized_tree)
         .unwrap();
-    // Commit the batch: RocksTxn buffers writes until `commit()`.
-    txn.commit().unwrap();
 
     let svc = NodeRpcServer::new()
         .with_hypergraph_store(store.clone() as Arc<dyn HypergraphStore>);
@@ -171,19 +161,9 @@ async fn get_hyperedge_data_returns_known_indices() {
     };
 
     let (serialized_tree, leaves) = build_and_serialize();
-    let txn = store.new_transaction(false).unwrap();
     store
-        .insert_node(
-            txn.as_ref(),
-            "hyperedge",
-            "adds",
-            &shard,
-            &address,
-            &[],
-            &serialized_tree,
-        )
+        .save_vertex_underlying("hyperedge", "adds", &shard, &address, &serialized_tree)
         .unwrap();
-    txn.commit().unwrap();
 
     let svc = NodeRpcServer::new()
         .with_hypergraph_store(store.clone() as Arc<dyn HypergraphStore>);
@@ -206,4 +186,109 @@ async fn get_hyperedge_data_returns_known_indices() {
             .unwrap_or_else(|| panic!("missing entry for key {:?}", k));
         assert_eq!(&found.value, v);
     }
+}
+
+#[tokio::test]
+async fn get_vertex_data_round_trips_through_real_commit_path() {
+    // Stronger variant of `get_vertex_data_round_trips_inserted_leaves`.
+    //
+    // The tests above hand-write the per-vertex blob with a direct
+    // `save_vertex_underlying` call. That proves the handler's
+    // load → `deserialize_go_tree` → canonical-index enumeration is
+    // internally correct, but it does NOT prove byte-compatibility with
+    // what production actually persists: the writer is mocked.
+    //
+    // In production nothing calls `save_vertex_underlying` by hand for a
+    // vertex. The blob lands in the per-vertex keyspace as a side effect
+    // of committing the *global* hypergraph tree: `LazyVectorCommitmentTree
+    // ::commit` walks every leaf and persists its `value` via
+    // `walk_leaves_persist` → `save_vertex_underlying`
+    // (see `crates/quil-tries/src/lazy_tree.rs`). The global-tree leaf's
+    // `value` IS the serialized underlying sub-tree, which is exactly what
+    // `GetVertexData` later deserializes.
+    //
+    // So this test drives the real write path end-to-end: build a lazy
+    // tree over the same (set, phase, shard), insert a leaf keyed by the
+    // 64-byte vertex address whose value is the serialized sub-tree, then
+    // `commit`. If the lazy commit's per-vertex persistence ever drifts
+    // from the keyspace/format the handler reads, this fails where the
+    // hand-written variant would stay green.
+    let tmp = TempDir::new().unwrap();
+    let db = RocksDb::open(tmp.path()).unwrap();
+    let store = Arc::new(RocksHypergraphStore::new(Arc::new(db).inner()));
+
+    let mut address = vec![0u8; 64];
+    for (i, b) in address.iter_mut().enumerate().take(32) {
+        *b = 0x30 + i as u8;
+    }
+    let app_address = &address[..32];
+    let shard = ShardKey {
+        l1: quil_hypergraph::addressing::get_bloom_filter_indices(app_address, 256, 3),
+        l2: {
+            let mut l2 = [0u8; 32];
+            l2.copy_from_slice(app_address);
+            l2
+        },
+    };
+
+    let (serialized_tree, leaves) = build_and_serialize();
+
+    // Persist via the production path: commit a lazy global tree whose one
+    // leaf carries the serialized sub-tree as its value.
+    let lazy = LazyVectorCommitmentTree::new(
+        store.clone() as Arc<dyn HypergraphStore>,
+        "vertex",
+        "adds",
+        shard.clone(),
+        Vec::new(), // empty covered_prefix → no shard-range gate
+    );
+    lazy.insert(
+        &address,
+        &serialized_tree,
+        &[],
+        &BigInt::from(serialized_tree.len() as u64),
+    )
+    .unwrap();
+    let txn = store.new_transaction(false).unwrap();
+    let prover = KzgInclusionProver;
+    lazy.commit(txn.as_ref(), &prover).unwrap();
+    txn.commit().unwrap();
+
+    let svc = NodeRpcServer::new()
+        .with_hypergraph_store(store.clone() as Arc<dyn HypergraphStore>);
+
+    let resp = svc
+        .get_vertex_data(Request::new(GetVertexDataRequest {
+            address: address.clone(),
+            full_data: false,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp.set_type, "vertex");
+    assert_eq!(resp.phase_type, "adds");
+    assert_eq!(
+        resp.entries.len(),
+        leaves.len(),
+        "lazy-commit-persisted blob must enumerate the same leaves"
+    );
+    for (k, v) in &leaves {
+        let found = resp
+            .entries
+            .iter()
+            .find(|e| &e.key == k)
+            .unwrap_or_else(|| panic!("missing entry for key {:?}", k));
+        assert_eq!(&found.value, v, "value mismatch for key {:?}", k);
+    }
+
+    // full_data=true must hand back the exact bytes the lazy commit wrote.
+    let resp_full = svc
+        .get_vertex_data(Request::new(GetVertexDataRequest {
+            address: address.clone(),
+            full_data: true,
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(resp_full.raw_data, serialized_tree);
 }

--- a/crates/quil-store/Cargo.toml
+++ b/crates/quil-store/Cargo.toml
@@ -5,6 +5,12 @@ edition = "2021"
 license = "Apache-2.0"
 description = "RocksDB-backed storage implementations for the Quilibrium node"
 
+[features]
+# Exposes non-transactional store helpers (e.g. the direct
+# `save_vertex_underlying`) for use as test fixtures. Off in production
+# builds; enable from a consuming crate's `[dev-dependencies]`.
+test-utils = []
+
 [dependencies]
 quil-types = { path = "../quil-types" }
 quil-config = { path = "../quil-config" }

--- a/crates/quil-store/src/hypergraph.rs
+++ b/crates/quil-store/src/hypergraph.rs
@@ -55,16 +55,11 @@ impl RocksHypergraphStore {
     /// batch so the blob becomes durable atomically with the rest of the
     /// transaction.
     ///
-    /// Unlike the generic [`HypergraphStore`] writers, this deliberately
-    /// does NOT fall back to a direct write when `txn` isn't a `RocksTxn`.
-    /// A silent fallback would persist the blob outside the caller's
-    /// transaction, defeating the atomicity this method exists to provide.
-    /// The only caller obtains `txn` from [`new_transaction`], which always
-    /// yields a `RocksTxn`, so the batch path always applies; an
-    /// unrecognized txn is a programming error and is surfaced loudly
-    /// rather than masked by a non-transactional write.
-    ///
-    /// [`new_transaction`]: quil_types::store::HypergraphStore::new_transaction
+    /// Like every other `RocksHypergraphStore` writer, this stages into the
+    /// txn's batch and errors (rather than writing directly) if `txn` isn't a
+    /// `RocksTxn` — see [`RocksTxn::from_dyn`]. A silent fallback would
+    /// persist the blob outside the caller's transaction, defeating the
+    /// atomicity this method exists to provide.
     pub fn save_tree_blob_txn(
         &self,
         txn: &dyn Transaction,
@@ -74,13 +69,8 @@ impl RocksHypergraphStore {
         bytes: &[u8],
     ) -> Result<()> {
         let key = hypergraph_tree_blob_key(set_type, phase_type, shard_key);
-        if with_rocks_batch(txn, |b| b.put(&key, bytes)) {
-            return Ok(());
-        }
-        Err(QuilError::Internal(
-            "save_tree_blob_txn requires a RocksTxn; refusing to write outside the transaction"
-                .into(),
-        ))
+        RocksTxn::from_dyn(txn)?.batch.lock().unwrap().put(&key, bytes);
+        Ok(())
     }
 
     /// Load a previously stored tree blob, or `Ok(None)` if no blob exists
@@ -125,8 +115,8 @@ impl RocksHypergraphStore {
     /// Transaction-aware variant of [`save_vertex_underlying`]: stages the
     /// write into `txn`'s batch so vertex content becomes durable
     /// atomically with the tree nodes and shard commit of the surrounding
-    /// transaction, falling back to a direct write for an unrecognized txn
-    /// type.
+    /// transaction. Errors for an unrecognized txn type rather than writing
+    /// outside the transaction (see [`RocksTxn::from_dyn`]).
     pub fn save_vertex_underlying_txn(
         &self,
         txn: &dyn Transaction,
@@ -137,12 +127,8 @@ impl RocksHypergraphStore {
         bytes: &[u8],
     ) -> Result<()> {
         let key = hypergraph_vertex_data_key(set_type, phase_type, shard_key, vertex_key);
-        if with_rocks_batch(txn, |b| b.put(&key, bytes)) {
-            return Ok(());
-        }
-        self.db
-            .put(&key, bytes)
-            .map_err(|e| QuilError::Store(e.to_string()))
+        RocksTxn::from_dyn(txn)?.batch.lock().unwrap().put(&key, bytes);
+        Ok(())
     }
 
     /// Load one vertex's `underlying_data`, or `Ok(None)` if absent.
@@ -320,20 +306,32 @@ impl Transaction for RocksTxn {
     }
 }
 
-/// If `txn` is a `RocksTxn`, stage `op` into its write batch and
-/// return `true`; else return `false` so the caller can fall back
-/// to direct DB writes.
-#[inline]
-fn with_rocks_batch<F>(txn: &dyn Transaction, op: F) -> bool
-where
-    F: FnOnce(&mut rocksdb::WriteBatch),
-{
-    if let Some(rt) = txn.as_any().downcast_ref::<RocksTxn>() {
-        let mut guard = rt.batch.lock().unwrap();
-        op(&mut *guard);
-        true
-    } else {
-        false
+impl RocksTxn {
+    /// Recover the concrete `RocksTxn` from the `&dyn Transaction` that the
+    /// [`HypergraphStore`] trait hands every writer. The trait must stay
+    /// `dyn`-typed (it has several store implementors and is used as
+    /// `Arc<dyn HypergraphStore>`), but every txn reaching a
+    /// `RocksHypergraphStore` write is obtained from [`new_transaction`],
+    /// which always yields a `RocksTxn` — so this downcast always succeeds
+    /// in practice.
+    ///
+    /// It deliberately errors (rather than letting the caller fall back to a
+    /// direct `db.put`/`db.delete`) for an unrecognized txn: a silent direct
+    /// write would persist outside the caller's transaction, breaking the
+    /// atomicity these writers exist to provide (and masking bugs like a
+    /// no-op txn leaking writes to disk — the defect that made
+    /// `compute_shard_root` non-read-only). An unrecognized txn is a
+    /// programming error and is surfaced loudly.
+    ///
+    /// [`HypergraphStore`]: quil_types::store::HypergraphStore
+    /// [`new_transaction`]: quil_types::store::HypergraphStore::new_transaction
+    fn from_dyn(txn: &dyn Transaction) -> Result<&RocksTxn> {
+        txn.as_any().downcast_ref::<RocksTxn>().ok_or_else(|| {
+            QuilError::Internal(
+                "hypergraph store write requires a RocksTxn; refusing to write outside the transaction"
+                    .into(),
+            )
+        })
     }
 }
 
@@ -424,13 +422,8 @@ impl HypergraphStore for RocksHypergraphStore {
         // Root sentinel keeps its legacy blob route for backward compat.
         if key == [0xFFu8; 32] {
             let db_key = hypergraph_tree_blob_key(set_type, phase_type, shard_key);
-            if with_rocks_batch(txn, |b| b.put(&db_key, data)) {
-                return Ok(());
-            }
-            return self
-                .db
-                .put(&db_key, data)
-                .map_err(|e| QuilError::Store(e.to_string()));
+            RocksTxn::from_dyn(txn)?.batch.lock().unwrap().put(&db_key, data);
+            return Ok(());
         }
         // Per-node: write the by-key entry and the by-path pointer
         // atomically. Pointer value is the by-key key — the lazy
@@ -438,29 +431,16 @@ impl HypergraphStore for RocksHypergraphStore {
         // entry. This is exactly Go's dual-index scheme.
         let by_key = hypergraph_tree_node_by_key(set_type, phase_type, shard_key, key);
         let by_path = hypergraph_tree_node_by_path(set_type, phase_type, shard_key, path);
-        let by_key_for_pointer = by_key.clone();
-        if with_rocks_batch(txn, |b| {
-            b.put(&by_key, data);
-            b.put(&by_path, &by_key_for_pointer);
-        }) {
-            return Ok(());
-        }
-        self.db
-            .put(&by_key, data)
-            .map_err(|e| QuilError::Store(e.to_string()))?;
-        self.db
-            .put(&by_path, &by_key_for_pointer)
-            .map_err(|e| QuilError::Store(e.to_string()))
+        let mut batch = RocksTxn::from_dyn(txn)?.batch.lock().unwrap();
+        batch.put(&by_key, data);
+        batch.put(&by_path, &by_key);
+        Ok(())
     }
 
     fn save_root(&self, txn: &dyn Transaction, set_type: &str, phase_type: &str, shard_key: &ShardKey, data: &[u8]) -> Result<()> {
         let db_key = hypergraph_tree_blob_key(set_type, phase_type, shard_key);
-        if with_rocks_batch(txn, |b| b.put(&db_key, data)) {
-            return Ok(());
-        }
-        self.db
-            .put(&db_key, data)
-            .map_err(|e| QuilError::Store(e.to_string()))
+        RocksTxn::from_dyn(txn)?.batch.lock().unwrap().put(&db_key, data);
+        Ok(())
     }
 
     fn delete_node(
@@ -474,28 +454,15 @@ impl HypergraphStore for RocksHypergraphStore {
     ) -> Result<()> {
         if key == [0xFFu8; 32] {
             let db_key = hypergraph_tree_blob_key(set_type, phase_type, shard_key);
-            if with_rocks_batch(txn, |b| b.delete(&db_key)) {
-                return Ok(());
-            }
-            return self
-                .db
-                .delete(&db_key)
-                .map_err(|e| QuilError::Store(e.to_string()));
+            RocksTxn::from_dyn(txn)?.batch.lock().unwrap().delete(&db_key);
+            return Ok(());
         }
         let by_key = hypergraph_tree_node_by_key(set_type, phase_type, shard_key, key);
         let by_path = hypergraph_tree_node_by_path(set_type, phase_type, shard_key, path);
-        if with_rocks_batch(txn, |b| {
-            b.delete(&by_key);
-            b.delete(&by_path);
-        }) {
-            return Ok(());
-        }
-        self.db
-            .delete(&by_key)
-            .map_err(|e| QuilError::Store(e.to_string()))?;
-        self.db
-            .delete(&by_path)
-            .map_err(|e| QuilError::Store(e.to_string()))
+        let mut batch = RocksTxn::from_dyn(txn)?.batch.lock().unwrap();
+        batch.delete(&by_key);
+        batch.delete(&by_path);
+        Ok(())
     }
 
     fn set_covered_prefix(&self, prefix: &[i32]) -> Result<()> {
@@ -512,10 +479,8 @@ impl HypergraphStore for RocksHypergraphStore {
 
     fn set_shard_commit(&self, txn: &dyn Transaction, frame_number: u64, phase_type: &str, set_type: &str, shard_address: &[u8], commitment: &[u8]) -> Result<()> {
         let key = hypergraph_shard_commit_key(frame_number, phase_type, set_type, shard_address);
-        if with_rocks_batch(txn, |b| b.put(&key, commitment)) {
-            return Ok(());
-        }
-        self.db.put(&key, commitment).map_err(|e| QuilError::Store(e.to_string()))
+        RocksTxn::from_dyn(txn)?.batch.lock().unwrap().put(&key, commitment);
+        Ok(())
     }
 
     fn get_shard_commit(&self, frame_number: u64, phase_type: &str, set_type: &str, shard_address: &[u8]) -> Result<Vec<u8>> {
@@ -706,26 +671,13 @@ impl HypergraphStore for RocksHypergraphStore {
             _ => true,
         };
 
-        if with_rocks_batch(txn, |b| {
-            b.put(&commit_key, &value);
-            if should_update_latest {
-                b.put(&latest_key, frame_number.to_be_bytes());
-            }
-            b.put(&index_key, &[] as &[u8]);
-        }) {
-            return Ok(());
-        }
-
-        // Fallback path — no RocksTxn; use a local atomic batch.
-        let mut batch = rocksdb::WriteBatch::default();
+        let mut batch = RocksTxn::from_dyn(txn)?.batch.lock().unwrap();
         batch.put(&commit_key, &value);
         if should_update_latest {
             batch.put(&latest_key, frame_number.to_be_bytes());
         }
         batch.put(&index_key, &[] as &[u8]);
-        self.db
-            .write(batch)
-            .map_err(|e| QuilError::Store(e.to_string()))
+        Ok(())
     }
 
     fn get_latest_alt_shard_commit(
@@ -865,10 +817,8 @@ impl HypergraphStore for RocksHypergraphStore {
             "track_change: unknown set/phase pair ({}, {})", set_type, phase_type,
         )))?;
         let value: &[u8] = old_value.unwrap_or(&[]);
-        if with_rocks_batch(txn, |b| b.put(&change_key, value)) {
-            return Ok(());
-        }
-        self.db.put(&change_key, value).map_err(|e| QuilError::Store(e.to_string()))
+        RocksTxn::from_dyn(txn)?.batch.lock().unwrap().put(&change_key, value);
+        Ok(())
     }
     fn get_changes(
         &self,
@@ -946,10 +896,8 @@ impl HypergraphStore for RocksHypergraphStore {
         .ok_or_else(|| QuilError::InvalidArgument(format!(
             "untrack_change: unknown set/phase pair ({}, {})", set_type, phase_type,
         )))?;
-        if with_rocks_batch(txn, |b| b.delete(&change_key)) {
-            return Ok(());
-        }
-        self.db.delete(&change_key).map_err(|e| QuilError::Store(e.to_string()))
+        RocksTxn::from_dyn(txn)?.batch.lock().unwrap().delete(&change_key);
+        Ok(())
     }
 
     fn capture_tree_snapshot(&self) -> Result<Option<Arc<dyn SnapshotReadable>>> {

--- a/crates/quil-store/src/hypergraph.rs
+++ b/crates/quil-store/src/hypergraph.rs
@@ -33,6 +33,11 @@ impl RocksHypergraphStore {
     /// Save a fully-serialized vector commitment tree as a single blob,
     /// keyed by `(set_type, phase_type, shard_key)`. The bytes should be
     /// the output of `quil_tries::serialize_tree`.
+    ///
+    /// Test-only: production persists tree blobs transactionally via
+    /// [`save_tree_blob_txn`]. Kept for unit tests that don't need a
+    /// transaction around the write.
+    #[cfg(test)]
     pub fn save_tree_blob(
         &self,
         set_type: &str,
@@ -44,6 +49,38 @@ impl RocksHypergraphStore {
         self.db
             .put(&key, bytes)
             .map_err(|e| QuilError::Store(e.to_string()))
+    }
+
+    /// Transaction-aware tree-blob write: stages the put into `txn`'s
+    /// batch so the blob becomes durable atomically with the rest of the
+    /// transaction.
+    ///
+    /// Unlike the generic [`HypergraphStore`] writers, this deliberately
+    /// does NOT fall back to a direct write when `txn` isn't a `RocksTxn`.
+    /// A silent fallback would persist the blob outside the caller's
+    /// transaction, defeating the atomicity this method exists to provide.
+    /// The only caller obtains `txn` from [`new_transaction`], which always
+    /// yields a `RocksTxn`, so the batch path always applies; an
+    /// unrecognized txn is a programming error and is surfaced loudly
+    /// rather than masked by a non-transactional write.
+    ///
+    /// [`new_transaction`]: quil_types::store::HypergraphStore::new_transaction
+    pub fn save_tree_blob_txn(
+        &self,
+        txn: &dyn Transaction,
+        set_type: &str,
+        phase_type: &str,
+        shard_key: &ShardKey,
+        bytes: &[u8],
+    ) -> Result<()> {
+        let key = hypergraph_tree_blob_key(set_type, phase_type, shard_key);
+        if with_rocks_batch(txn, |b| b.put(&key, bytes)) {
+            return Ok(());
+        }
+        Err(QuilError::Internal(
+            "save_tree_blob_txn requires a RocksTxn; refusing to write outside the transaction"
+                .into(),
+        ))
     }
 
     /// Load a previously stored tree blob, or `Ok(None)` if no blob exists
@@ -60,8 +97,17 @@ impl RocksHypergraphStore {
             .map_err(|e| QuilError::Store(e.to_string()))
     }
 
-    /// Persist one vertex's `underlying_data` sub-tree blob. See
-    /// `quil_tries::deserialize_go_tree` for parsing the wire format.
+    /// Persist one vertex's `underlying_data` sub-tree blob directly,
+    /// outside any transaction. See `quil_tries::deserialize_go_tree` for
+    /// parsing the wire format.
+    ///
+    /// Test-only: production persists vertex content transactionally via
+    /// [`save_vertex_underlying_txn`] (or the `HypergraphStore` trait
+    /// method, which delegates to it). Kept as a direct-write fixture for
+    /// tests that seed the per-vertex keyspace without a transaction. Gated
+    /// behind the `test-utils` feature so it can't be reached from
+    /// production code; consuming crates enable it via `[dev-dependencies]`.
+    #[cfg(any(test, feature = "test-utils"))]
     pub fn save_vertex_underlying(
         &self,
         set_type: &str,
@@ -71,6 +117,29 @@ impl RocksHypergraphStore {
         bytes: &[u8],
     ) -> Result<()> {
         let key = hypergraph_vertex_data_key(set_type, phase_type, shard_key, vertex_key);
+        self.db
+            .put(&key, bytes)
+            .map_err(|e| QuilError::Store(e.to_string()))
+    }
+
+    /// Transaction-aware variant of [`save_vertex_underlying`]: stages the
+    /// write into `txn`'s batch so vertex content becomes durable
+    /// atomically with the tree nodes and shard commit of the surrounding
+    /// transaction, falling back to a direct write for an unrecognized txn
+    /// type.
+    pub fn save_vertex_underlying_txn(
+        &self,
+        txn: &dyn Transaction,
+        set_type: &str,
+        phase_type: &str,
+        shard_key: &ShardKey,
+        vertex_key: &[u8],
+        bytes: &[u8],
+    ) -> Result<()> {
+        let key = hypergraph_vertex_data_key(set_type, phase_type, shard_key, vertex_key);
+        if with_rocks_batch(txn, |b| b.put(&key, bytes)) {
+            return Ok(());
+        }
         self.db
             .put(&key, bytes)
             .map_err(|e| QuilError::Store(e.to_string()))
@@ -509,14 +578,15 @@ impl HypergraphStore for RocksHypergraphStore {
 
     fn save_vertex_underlying(
         &self,
+        txn: &dyn Transaction,
         set_type: &str,
         phase_type: &str,
         shard_key: &ShardKey,
         vertex_key: &[u8],
         data: &[u8],
     ) -> Result<()> {
-        RocksHypergraphStore::save_vertex_underlying(
-            self, set_type, phase_type, shard_key, vertex_key, data,
+        RocksHypergraphStore::save_vertex_underlying_txn(
+            self, txn, set_type, phase_type, shard_key, vertex_key, data,
         )
     }
 

--- a/crates/quil-tries/src/lazy_tree.rs
+++ b/crates/quil-tries/src/lazy_tree.rs
@@ -749,6 +749,27 @@ impl LazyVectorCommitmentTree {
             .insert(by_key, (by_path, node));
     }
 
+    /// Compute the current root commitment **in memory only** — the
+    /// read-only half of `commit`. Walks the in-memory tree under the
+    /// root write guard, recomputing any branch whose `commitment` field
+    /// was cleared by Insert (bottom-up; cached commitments are left
+    /// intact, matching Go's `recalculate=false` short-circuit in
+    /// `commitNode`), and returns the root. Writes nothing to the store
+    /// and does not touch dirty / pending-deletion / dirty-flag
+    /// bookkeeping, so it is safe to call for an uncommitted frame on a
+    /// hot path. Use `commit` (with a real txn) to persist.
+    pub fn compute_root(
+        &self,
+        prover: &(dyn InclusionProver + Sync),
+    ) -> Result<Vec<u8>> {
+        self.ensure_root_loaded()?;
+        let mut root_guard = self.root.write().unwrap();
+        match root_guard.as_mut() {
+            Some(Some(node)) => self.commit_recursive(node, prover),
+            _ => Ok(vec![0u8; 64]),
+        }
+    }
+
     /// Commit: walk the in-memory tree top-down, recomputing every
     /// commitment whose `commitment` field was cleared by Insert,
     /// then persist all touched nodes via `Store.insert_node(txn, ...)`
@@ -767,21 +788,8 @@ impl LazyVectorCommitmentTree {
         txn: &dyn Transaction,
         prover: &(dyn InclusionProver + Sync),
     ) -> Result<Vec<u8>> {
-        self.ensure_root_loaded()?;
-
-        // Recompute commitments. The walker mutates the in-memory
-        // tree under the root write guard: any branch whose
-        // `commitment` field was cleared by Insert is recomputed
-        // bottom-up; cached commitments are left intact (matches
-        // Go's `recalculate=false` short-circuit semantic in
-        // `commitNode`).
-        let root_commitment = {
-            let mut root_guard = self.root.write().unwrap();
-            match root_guard.as_mut() {
-                Some(Some(node)) => self.commit_recursive(node, prover)?,
-                _ => vec![0u8; 64],
-            }
-        };
+        // Recompute commitments in memory (the read-only half of commit).
+        let root_commitment = self.compute_root(prover)?;
 
         // Stage every dirty node + the latest root into the txn. We take a
         // non-draining *snapshot* of the dirty set (just the `(by_key,

--- a/crates/quil-tries/src/lazy_tree.rs
+++ b/crates/quil-tries/src/lazy_tree.rs
@@ -783,20 +783,22 @@ impl LazyVectorCommitmentTree {
             }
         };
 
-        // Persist every dirty node + the latest root via the txn.
-        // After persistence the dirty map is cleared — fresh Inserts
-        // will repopulate it.
-        let dirty = std::mem::take(&mut *self.dirty.write().unwrap());
-        let mut latest: HashMap<Vec<u8>, (Vec<i32>, VectorCommitmentNode)> = HashMap::new();
-        for (k, (p, _)) in dirty.iter() {
-            latest.insert(k.clone(), (p.clone(), VectorCommitmentNode::Leaf(LeafNode {
-                key: vec![],
-                value: vec![],
-                hash_target: vec![],
-                commitment: vec![],
-                size: BigInt::zero(),
-            })));
-        }
+        // Stage every dirty node + the latest root into the txn. We take a
+        // non-draining *snapshot* of the dirty set (just the `(by_key,
+        // by_path)` locators — the node body is pulled fresh from the
+        // in-memory tree below) and leave the dirty bookkeeping intact. It
+        // is cleared only once the caller confirms the surrounding
+        // transaction committed, via `mark_persisted`. This keeps commit
+        // retry-safe: if the txn is aborted or never commits, the dirty set
+        // survives and a retry re-stages these writes rather than silently
+        // skipping them.
+        let dirty: Vec<(Vec<u8>, Vec<i32>)> = self
+            .dirty
+            .read()
+            .unwrap()
+            .iter()
+            .map(|(by_key, (by_path, _))| (by_key.clone(), by_path.clone()))
+            .collect();
         // Re-walk the in-memory tree to pull the freshly-committed
         // nodes for every entry in `dirty`. The cheap way: index in-
         // memory nodes by their by_key bytes and look them up.
@@ -808,7 +810,7 @@ impl LazyVectorCommitmentTree {
             }
             idx
         };
-        for (by_key, (by_path, _)) in dirty.into_iter() {
+        for (by_key, by_path) in dirty.into_iter() {
             // Prefer the freshly-committed in-memory copy. If a dirty
             // entry can't be located in the in-memory tree (e.g. a
             // branch displaced by a split, or a leaf that got
@@ -833,8 +835,10 @@ impl LazyVectorCommitmentTree {
             )?;
         }
 
-        // Drop orphaned by-path entries from branch splits.
-        let deletions = std::mem::take(&mut *self.pending_deletions.write().unwrap());
+        // Drop orphaned by-path entries from branch splits. Snapshot (don't
+        // drain) so the deletions also survive an aborted txn for retry;
+        // `mark_persisted` clears them after the caller confirms commit.
+        let deletions = self.pending_deletions.read().unwrap().clone();
         for (by_key, by_path) in deletions {
             // `delete_node` clears both the by-key entry and the
             // by-path pointer (per `RocksHypergraphStore::delete_node`).
@@ -876,7 +880,14 @@ impl LazyVectorCommitmentTree {
             }
         }
 
-        *self.dirty_flag.write().unwrap() = false;
+        // NOTE: dirty bookkeeping (the dirty map, pending deletions, and
+        // dirty flag) is deliberately NOT cleared here. These writes are
+        // only *staged* into `txn`; they become durable when the caller
+        // commits it. The caller signals that with `mark_persisted`, which
+        // is the sole place the dirty state is cleared. Clearing here would
+        // make an aborted/failed/never-committed txn leave the store empty
+        // while the tree believes it persisted — and a retry would skip
+        // re-staging.
         Ok(root_commitment)
     }
 
@@ -1109,6 +1120,18 @@ impl LazyVectorCommitmentTree {
 
     pub fn is_dirty(&self) -> bool {
         *self.dirty_flag.read().unwrap()
+    }
+
+    /// Clear dirty bookkeeping after the transaction that `commit` staged
+    /// into has been durably committed by the caller. Must be called ONLY
+    /// after `txn.commit()` succeeds — calling it earlier reintroduces the
+    /// retry-unsafety the deferred-clear split is designed to fix (a
+    /// failed/aborted batch would leave the store empty while the tree
+    /// believes it persisted). Idempotent.
+    pub fn mark_persisted(&self) {
+        self.dirty.write().unwrap().clear();
+        self.pending_deletions.write().unwrap().clear();
+        *self.dirty_flag.write().unwrap() = false;
     }
 }
 

--- a/crates/quil-tries/src/lazy_tree.rs
+++ b/crates/quil-tries/src/lazy_tree.rs
@@ -867,6 +867,7 @@ impl LazyVectorCommitmentTree {
             if let Some(Some(node)) = root_guard.as_ref() {
                 walk_leaves_persist(
                     node,
+                    txn,
                     self.store.as_ref(),
                     &self.set_type,
                     &self.phase_type,
@@ -1168,6 +1169,7 @@ fn index_by_key(
 /// keyspace. Mirrors `lazy_tree::commit`'s vertex-data loop.
 fn walk_leaves_persist(
     node: &VectorCommitmentNode,
+    txn: &dyn Transaction,
     store: &dyn HypergraphStore,
     set_type: &str,
     phase_type: &str,
@@ -1175,12 +1177,12 @@ fn walk_leaves_persist(
 ) -> Result<()> {
     match node {
         VectorCommitmentNode::Leaf(l) if !l.value.is_empty() => {
-            store.save_vertex_underlying(set_type, phase_type, shard_key, &l.key, &l.value)
+            store.save_vertex_underlying(txn, set_type, phase_type, shard_key, &l.key, &l.value)
         }
         VectorCommitmentNode::Leaf(_) => Ok(()),
         VectorCommitmentNode::Branch(b) => {
             for child in b.children.iter().flatten() {
-                walk_leaves_persist(child, store, set_type, phase_type, shard_key)?;
+                walk_leaves_persist(child, txn, store, set_type, phase_type, shard_key)?;
             }
             Ok(())
         }

--- a/crates/quil-tries/tests/golden_lazy_tree.rs
+++ b/crates/quil-tries/tests/golden_lazy_tree.rs
@@ -150,6 +150,19 @@ impl BTreeStore {
         Arc::new(Self::default())
     }
 
+    /// Number of tree-node entries currently persisted (by-key +
+    /// by-path). Used to observe whether a commit re-stages node writes.
+    fn kv_len(&self) -> usize {
+        self.inner.lock().unwrap().kv.len()
+    }
+
+    /// Discard all persisted tree nodes, simulating a surrounding
+    /// transaction that was aborted / never committed after `commit`
+    /// staged into it.
+    fn clear_kv(&self) {
+        self.inner.lock().unwrap().kv.clear();
+    }
+
     // Key builders. These MUST match `quil_store::encoding`:
     //   HG_TREE_NODE_BY_KEY  = 0x33
     //   HG_TREE_NODE_BY_PATH = 0x34
@@ -1008,5 +1021,78 @@ fn golden_small_scatter() {
 #[test]
 fn golden_medium_scatter() {
     assert_matches_golden(&GOLDENS[3]);
+}
+
+// ---------------------------------------------------------------------------
+// Retry-safety: `commit` must NOT consume its dirty bookkeeping before the
+// surrounding transaction is durably committed. The tree stays dirty (and a
+// retry re-stages every node write) until the caller confirms durability via
+// `mark_persisted`. See the "consumes dirty state before the outer
+// transaction commits" follow-up in the refactored-galaxy plan.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn commit_defers_dirty_clear_until_mark_persisted() {
+    let store = BTreeStore::new();
+    let tree = LazyVectorCommitmentTree::new(
+        store.clone() as Arc<dyn HypergraphStore>,
+        "vertex",
+        "adds",
+        shard_key_zero(),
+        vec![],
+    );
+
+    let mut ks = KeyStream::new(b"retry-safety");
+    for i in 0..5u64 {
+        let key = ks.next_key().to_vec();
+        let mut value = key.clone();
+        value.reverse();
+        let hash_target = deterministic_hash_target(&key, &value);
+        tree.insert(&key, &value, &hash_target, &BigInt::from(i + 1))
+            .unwrap();
+    }
+    assert!(tree.is_dirty(), "inserts must mark the tree dirty");
+
+    // Commit stages every node write. With the write-through BTreeStore the
+    // writes land immediately, but the tree must remain dirty until the
+    // caller confirms the surrounding txn actually committed. (Before the
+    // fix, `commit` cleared `dirty_flag` here and this assertion failed.)
+    let txn = arc_txn(store.clone());
+    tree.commit(txn.as_ref(), &StubProver).unwrap();
+    assert!(store.kv_len() > 0, "commit must stage node writes");
+    assert!(
+        tree.is_dirty(),
+        "commit must NOT clear dirty state before the caller confirms the txn",
+    );
+
+    // Simulate the surrounding transaction being discarded (abort / crash
+    // before `txn.commit()`): wipe everything the commit just staged.
+    store.clear_kv();
+    assert_eq!(store.kv_len(), 0);
+
+    // A retry must re-stage every node, because the dirty bookkeeping was
+    // never cleared. Before the fix the dirty map was already drained, so
+    // this second commit re-staged nothing and the store stayed empty.
+    let txn2 = arc_txn(store.clone());
+    tree.commit(txn2.as_ref(), &StubProver).unwrap();
+    assert!(
+        store.kv_len() > 0,
+        "retry after a discarded txn must re-stage the node writes",
+    );
+
+    // Once the caller confirms durability, `mark_persisted` clears the
+    // bookkeeping and the tree goes clean.
+    tree.mark_persisted();
+    assert!(!tree.is_dirty(), "mark_persisted must clear the dirty flag");
+
+    // A now-clean tree re-stages no node writes on a subsequent commit.
+    store.clear_kv();
+    let txn3 = arc_txn(store.clone());
+    tree.commit(txn3.as_ref(), &StubProver).unwrap();
+    assert_eq!(
+        store.kv_len(),
+        0,
+        "after mark_persisted a clean tree must not re-stage node writes",
+    );
 }
 

--- a/crates/quil-tries/tests/golden_lazy_tree.rs
+++ b/crates/quil-tries/tests/golden_lazy_tree.rs
@@ -430,12 +430,15 @@ impl HypergraphStore for BTreeStore {
     }
     fn save_vertex_underlying(
         &self,
+        _txn: &dyn Transaction,
         _set: &str,
         _phase: &str,
         _shard: &ShardKey,
         vertex_key: &[u8],
         data: &[u8],
     ) -> Result<()> {
+        // This in-memory store writes through immediately; the txn is a
+        // no-op here (matching `NoopTxn`'s write-through semantics).
         self.inner
             .lock()
             .unwrap()

--- a/crates/quil-types/src/store.rs
+++ b/crates/quil-types/src/store.rs
@@ -543,8 +543,7 @@ pub trait HypergraphStore: Send + Sync {
     /// content becomes durable atomically with the tree nodes and shard
     /// commit of the surrounding transaction — matching Go's
     /// `SaveVertexTree`, which threads the transaction through to
-    /// `txn.Set`. Store impls whose transaction type is not recognized
-    /// fall back to a direct write.
+    /// `txn.Set`. 
     fn save_vertex_underlying(
         &self,
         txn: &dyn Transaction,

--- a/crates/quil-types/src/store.rs
+++ b/crates/quil-types/src/store.rs
@@ -538,8 +538,16 @@ pub trait HypergraphStore: Send + Sync {
     /// `data` is the Go-serialized sub-tree blob. The per-vertex
     /// keyspace is the canonical record of vertex content; the lazy
     /// commitment tree blob is metadata-only.
+    ///
+    /// The write joins `txn` (staged into its batch) so that vertex
+    /// content becomes durable atomically with the tree nodes and shard
+    /// commit of the surrounding transaction — matching Go's
+    /// `SaveVertexTree`, which threads the transaction through to
+    /// `txn.Set`. Store impls whose transaction type is not recognized
+    /// fall back to a direct write.
     fn save_vertex_underlying(
         &self,
+        txn: &dyn Transaction,
         set_type: &str,
         phase_type: &str,
         shard_key: &ShardKey,


### PR DESCRIPTION
A vertex-data persistence test failure surfaced a broader problem where hypergraph writes could escape their surrounding transaction: persisting for uncommitted frames, leaking via a read path, or leaving the in-memory tree out of sync with the store on retry.

- **fix vertex data roundtrip test and add new one aa5274b8cd3d1c95824b3e328f2b2f213715290e** 
  - fixes https://github.com/QuilibriumNetwork/monorepo/issues/539, this made me look deeper into hypergraph persistence.
- **use tx when saving vertex data db439927d0b818a354fa9cb3dca3b5f99094e153**  
  - thread the txn through `save_vertex_underlying` so that vertex data isn't persisted if the tx reverts.
- **make `LazyVectorCommitmentTree::commit ` retry-safe c6c6398a7af52fa51f9e49461dfd1c5af05114af:** 
  - defer clearing dirty state until `txn.commit()` succeeds, so an aborted txn leaves the tree dirty for a safe retry (covers all staged writes, not just vertex data).
- **make `compute_shard_root` read-only 61db77433762b8b1ec2e61071457d17b0a7c3a53:** 
  - extract `compute_root()` so root comparison on the hot master-stream path stops leaking writes via the `NoopTxn` fallback.
- **require `RocksTxn` for store writes 4b61ab595e8066255e64346945e71d6956186190:** 
  - remove the silent direct-write fallback that masked the above bug; all writers now use the concrete `RocksTxn` batch and error loudly on an unrecognized txn.

See individual commit messages for full detail.
