### PR TITLE
Bound blossomsub memory, CPU, and connection liveness under an unwritable network

### DIFF
--- a/crates/quil-p2p/src/behaviour.rs
+++ b/crates/quil-p2p/src/behaviour.rs
@@ -262,6 +262,7 @@ impl BlossomSubBehaviour {
                         handler: NotifyHandler::Any,
                         event: HandlerIn {
                             rpc_data: rpc_data.clone(),
+                            bulk: false,
                         },
                     });
                 }
@@ -402,7 +403,7 @@ impl BlossomSubBehaviour {
             self.events.push_back(ToSwarm::NotifyHandler {
                 peer_id: *peer,
                 handler: NotifyHandler::Any,
-                event: HandlerIn { rpc_data: encoded.clone() },
+                event: HandlerIn { rpc_data: encoded.clone(), bulk: true },
             });
         }
         // TEMP mesh-debug: surface exactly what the leader can reach so we can
@@ -448,17 +449,24 @@ impl BlossomSubBehaviour {
     }
 
     /// Backpressure guard for the outbound `self.events` queue. The swarm
-    /// drains it one entry per `poll`; if the application consuming
-    /// `SwarmEvent::Behaviour` stalls (busy/blocked), inbound `Message`
-    /// deliveries accumulate without bound — the regular-node OOM (jeprof:
-    /// dominant stack through `on_connection_handler_event`, ~18M ~1KiB
-    /// `pb::Message` clones, 30+ GB).
+    /// drains it one entry per `poll`; if the swarm consumer stalls or the
+    /// transport backs up, the bulky payload-carrying events accumulate
+    /// without bound — the regular-node OOM (jeprof: dominant stack through
+    /// `on_connection_handler_event`, ~18M ~1KiB clones, 30+ GB).
     ///
-    /// When the queue exceeds the high-water mark, drop the OLDEST app-bound
-    /// `Message` deliveries (gossip tolerates message loss; a stalled app
-    /// can't use them anyway) down to the low-water mark, while PRESERVING
-    /// every `NotifyHandler` control event (graft/prune/forward/IWANT) so the
-    /// mesh and forwarding stay intact.
+    /// Two kinds of events carry full message payloads:
+    ///   1. app-bound `Message` deliveries (`ToSwarm::GenerateEvent`), and
+    ///   2. `NotifyHandler` events tagged `bulk` — forwards, local publishes,
+    ///      and IWANT responses (each holds a full `encoded` RPC ~1KiB).
+    /// A relay node subscribed to nothing on a bitmask emits ONLY (2), so a
+    /// guard that drops only (1) never bounds the queue — that was the
+    /// still-OOMing bug this replaces.
+    ///
+    /// When the queue exceeds the high-water mark, drop the OLDEST bulk events
+    /// of either kind (gossip tolerates message loss; a stalled consumer can't
+    /// use them anyway) down to the low-water mark, while PRESERVING every
+    /// small control event (graft/prune/IWANT-request/IHAVE/IDONTWANT/
+    /// subscribe) so the mesh and gossip stay intact.
     fn shed_overflow_events(&mut self) {
         const HIGH_WATER: usize = 200_000;
         const LOW_WATER: usize = 150_000;
@@ -470,12 +478,15 @@ impl BlossomSubBehaviour {
         let mut kept: VecDeque<ToSwarm<BlossomSubEvent, HandlerIn>> =
             VecDeque::with_capacity(LOW_WATER + 1);
         for ev in std::mem::take(&mut self.events) {
-            if removed < target_remove
-                && matches!(
-                    &ev,
-                    ToSwarm::GenerateEvent(BlossomSubEvent::Message { .. })
-                )
-            {
+            let is_bulk = matches!(
+                &ev,
+                ToSwarm::GenerateEvent(BlossomSubEvent::Message { .. })
+                    | ToSwarm::NotifyHandler {
+                        event: HandlerIn { bulk: true, .. },
+                        ..
+                    }
+            );
+            if removed < target_remove && is_bulk {
                 removed += 1;
                 continue;
             }
@@ -485,8 +496,8 @@ impl BlossomSubBehaviour {
         warn!(
             dropped = removed,
             remaining = self.events.len(),
-            "blossomsub: shed inbound messages — swarm consumer not draining \
-             (OOM backpressure guard); control events preserved"
+            "blossomsub: shed bulk message/forward events — swarm consumer not \
+             draining (OOM backpressure guard); control events preserved"
         );
     }
 
@@ -652,6 +663,7 @@ impl BlossomSubBehaviour {
                         handler: NotifyHandler::Any,
                         event: HandlerIn {
                             rpc_data: encoded.clone(),
+                            bulk: true,
                         },
                     });
                 }
@@ -695,6 +707,7 @@ impl BlossomSubBehaviour {
                                 handler: NotifyHandler::Any,
                                 event: HandlerIn {
                                     rpc_data: encoded_idontwant.clone(),
+                                    bulk: false,
                                 },
                             });
                         }
@@ -1026,7 +1039,7 @@ impl BlossomSubBehaviour {
                     self.events.push_back(ToSwarm::NotifyHandler {
                         peer_id: peer,
                         handler: NotifyHandler::Any,
-                        event: HandlerIn { rpc_data: encoded },
+                        event: HandlerIn { rpc_data: encoded, bulk: false },
                     });
                 }
             }
@@ -1058,7 +1071,7 @@ impl BlossomSubBehaviour {
                         self.events.push_back(ToSwarm::NotifyHandler {
                             peer_id: peer,
                             handler: NotifyHandler::Any,
-                            event: HandlerIn { rpc_data: encoded },
+                            event: HandlerIn { rpc_data: encoded, bulk: true },
                         });
                     }
                 }
@@ -1102,6 +1115,7 @@ impl BlossomSubBehaviour {
                     handler: NotifyHandler::Any,
                     event: HandlerIn {
                         rpc_data: rpc_data.clone(),
+                        bulk: false,
                     },
                 });
             }
@@ -1453,7 +1467,7 @@ impl BlossomSubBehaviour {
                 self.events.push_back(ToSwarm::NotifyHandler {
                     peer_id: target,
                     handler: NotifyHandler::Any,
-                    event: HandlerIn { rpc_data: encoded },
+                    event: HandlerIn { rpc_data: encoded, bulk: false },
                 });
             }
         }
@@ -1809,7 +1823,7 @@ impl BlossomSubBehaviour {
                             self.events.push_back(ToSwarm::NotifyHandler {
                                 peer_id: peer,
                                 handler: NotifyHandler::One(conn),
-                                event: HandlerIn { rpc_data: encoded.clone() },
+                                event: HandlerIn { rpc_data: encoded.clone(), bulk: false },
                             });
                         }
                     }
@@ -1928,7 +1942,7 @@ impl BlossomSubBehaviour {
                 self.events.push_back(ToSwarm::NotifyHandler {
                     peer_id: *peer,
                     handler: NotifyHandler::One(conn),
-                    event: HandlerIn { rpc_data: encoded },
+                    event: HandlerIn { rpc_data: encoded, bulk: false },
                 });
             }
         }
@@ -1944,7 +1958,7 @@ impl BlossomSubBehaviour {
                 self.events.push_back(ToSwarm::NotifyHandler {
                     peer_id: *peer,
                     handler: NotifyHandler::One(conn),
-                    event: HandlerIn { rpc_data: encoded },
+                    event: HandlerIn { rpc_data: encoded, bulk: false },
                 });
                 // Set backoff
                 self.backoffs.insert(
@@ -2038,6 +2052,7 @@ impl NetworkBehaviour for BlossomSubBehaviour {
                         handler: NotifyHandler::Any,
                         event: HandlerIn {
                             rpc_data: rpc_data.clone(),
+                            bulk: false,
                         },
                     });
                 }
@@ -2233,6 +2248,56 @@ mod composite_tests {
         let len = bh.events.len();
         bh.shed_overflow_events();
         assert_eq!(bh.events.len(), len, "no-op when already under the cap");
+    }
+
+    #[test]
+    fn shed_overflow_bounds_queue_dominated_by_forwards() {
+        // REGRESSION: a relay node not subscribed to a bitmask emits ZERO
+        // `Message` GenerateEvents — it only enqueues `NotifyHandler` FORWARDS
+        // (each carrying a full ~1KiB encoded RPC). The old guard sheds only
+        // `Message` events, so it found nothing to drop and the queue grew
+        // unbounded to OOM (36 GB). The guard must shed `bulk` NotifyHandler
+        // events too, while preserving small control RPCs.
+        let mut bh = BlossomSubBehaviour::new(0);
+        let peer = PeerId::random();
+        let mut control_pushed = 0usize;
+        for i in 0..260_000u32 {
+            // Bulk forward — the floodable, payload-carrying path.
+            bh.events.push_back(ToSwarm::NotifyHandler {
+                peer_id: peer,
+                handler: NotifyHandler::Any,
+                event: HandlerIn { rpc_data: vec![0u8; 1024], bulk: true },
+            });
+            // Interleave small control RPCs that MUST survive shedding.
+            if i % 40_000 == 0 {
+                bh.events.push_back(ToSwarm::NotifyHandler {
+                    peer_id: peer,
+                    handler: NotifyHandler::Any,
+                    event: HandlerIn { rpc_data: vec![0u8; 8], bulk: false },
+                });
+                control_pushed += 1;
+            }
+        }
+        assert!(bh.events.len() > 200_000);
+        bh.shed_overflow_events();
+        assert!(
+            bh.events.len() <= 200_000,
+            "queue must be bounded even when dominated by forwards"
+        );
+        let control_after = bh
+            .events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    ToSwarm::NotifyHandler { event: HandlerIn { bulk: false, .. }, .. }
+                )
+            })
+            .count();
+        assert_eq!(
+            control_after, control_pushed,
+            "control RPCs must survive shedding"
+        );
     }
 
     #[test]

--- a/crates/quil-p2p/src/behaviour.rs
+++ b/crates/quil-p2p/src/behaviour.rs
@@ -166,6 +166,7 @@ impl BlossomSubBehaviour {
     pub fn with_params(network: u8, params: crate::BlossomsubParams) -> Self {
         let mcache_len = params.history_length;
         let mcache_gossip = params.history_gossip;
+        let mcache_max_bytes = params.mcache_max_bytes;
         Self {
             subscriptions: HashSet::new(),
             peer_subscriptions: HashMap::new(),
@@ -185,6 +186,7 @@ impl BlossomSubBehaviour {
             mcache: crate::blossomsub::MessageCache::new(
                 mcache_len,
                 mcache_gossip,
+                mcache_max_bytes,
             ),
             last_heartbeat: Instant::now(),
             pending_subscribe_rpc: None,
@@ -1538,6 +1540,34 @@ impl BlossomSubBehaviour {
 
     fn heartbeat(&mut self) {
         self.heartbeat_ticks += 1;
+
+        // Periodic memory gauge for the unbounded-growth structures behind the
+        // regular-node OOM. Frame-pointer-less release builds collapse jeprof
+        // onto `on_connection_handler_event`, hiding WHICH structure grows;
+        // this log makes it observable. ~32 heartbeats ≈ 22s at 700ms.
+        if self.heartbeat_ticks % 32 == 0 {
+            let events = self.events.len();
+            let mcache_bytes = self.mcache.byte_len();
+            let mcache_msgs = self.mcache.len();
+            debug!(
+                events,
+                mcache_msgs,
+                mcache_bytes,
+                seen = self.seen_messages.len(),
+                pending_iwants = self.pending_iwants.len(),
+                peer_subs = self.peer_subscriptions.len(),
+                "blossomsub memory gauge"
+            );
+            // Surface at WARN if any bulk structure is climbing toward OOM.
+            if events > 100_000 || mcache_bytes > 256 * 1024 * 1024 {
+                warn!(
+                    events,
+                    mcache_msgs,
+                    mcache_bytes,
+                    "blossomsub: bulk buffers elevated (backpressure / catch-up)"
+                );
+            }
+        }
 
         // 0a. IWANT follow-up. For every pending IWANT older than
         // `params.iwant_followup_time`, either retry from another

--- a/crates/quil-p2p/src/blossomsub.rs
+++ b/crates/quil-p2p/src/blossomsub.rs
@@ -82,7 +82,7 @@ impl BlossomSubRouter {
             last_pub: HashMap::new(),
             backoff: HashMap::new(),
             outbound: HashMap::new(),
-            mcache: MessageCache::new(HISTORY_LENGTH, HISTORY_GOSSIP),
+            mcache: MessageCache::new(HISTORY_LENGTH, HISTORY_GOSSIP, MCACHE_MAX_BYTES),
         }
     }
 
@@ -336,6 +336,13 @@ pub struct MessageCache {
     history_length: usize,
     /// Number of windows to include in gossip.
     history_gossip: usize,
+    /// Hard cap on total cached payload bytes. When exceeded, the OLDEST
+    /// windows are evicted early (before `history_length`) so a catch-up
+    /// flood of large subscribed messages can't drive OOM. Window-count
+    /// history alone does not bound bytes.
+    max_bytes: usize,
+    /// Running total of `entry_bytes` over every cached message.
+    cur_bytes: usize,
 }
 
 #[derive(Clone)]
@@ -345,28 +352,72 @@ struct CachedMessage {
     pub _from: PeerId,
 }
 
+/// Approximate retained-heap cost of one cached message (the dominant
+/// allocations: the id key, the bitmask, and the payload).
+fn entry_bytes(id: &[u8], m: &CachedMessage) -> usize {
+    id.len() + m.bitmask.len() + m.data.len()
+}
+
 impl MessageCache {
-    pub fn new(history_length: usize, history_gossip: usize) -> Self {
+    pub fn new(history_length: usize, history_gossip: usize, max_bytes: usize) -> Self {
         Self {
             windows: vec![Vec::new()],
             messages: HashMap::new(),
             history_length,
             history_gossip,
+            max_bytes,
+            cur_bytes: 0,
         }
+    }
+
+    /// Number of messages currently cached (for diagnostics).
+    pub fn len(&self) -> usize {
+        self.messages.len()
+    }
+
+    /// Total cached payload bytes (for diagnostics / OOM gauges).
+    pub fn byte_len(&self) -> usize {
+        self.cur_bytes
     }
 
     /// Add a message to the current window.
     pub fn put(&mut self, msg_id: Vec<u8>, bitmask: Vec<u8>, data: Vec<u8>, from: PeerId) {
-        self.messages.insert(
+        let added = msg_id.len() + bitmask.len() + data.len();
+        match self.messages.insert(
             msg_id.clone(),
             CachedMessage {
                 bitmask,
                 data,
                 _from: from,
             },
-        );
-        if let Some(window) = self.windows.last_mut() {
-            window.push(msg_id);
+        ) {
+            // Replacing an existing id (dedup normally prevents this; the id
+            // already sits in a window). Adjust the byte total in place.
+            Some(old) => {
+                self.cur_bytes = self
+                    .cur_bytes
+                    .saturating_sub(msg_id.len() + old.bitmask.len() + old.data.len());
+            }
+            None => {
+                if let Some(window) = self.windows.last_mut() {
+                    window.push(msg_id);
+                }
+            }
+        }
+        self.cur_bytes += added;
+        self.evict_to_budget();
+    }
+
+    /// Drop whole windows from the front until under the byte budget, never
+    /// evicting the current (last) window we are still writing into.
+    fn evict_to_budget(&mut self) {
+        while self.cur_bytes > self.max_bytes && self.windows.len() > 1 {
+            let old = self.windows.remove(0);
+            for id in old {
+                if let Some(m) = self.messages.remove(&id) {
+                    self.cur_bytes = self.cur_bytes.saturating_sub(entry_bytes(&id, &m));
+                }
+            }
         }
     }
 
@@ -399,7 +450,9 @@ impl MessageCache {
         if self.windows.len() > self.history_length {
             let old = self.windows.remove(0);
             for id in old {
-                self.messages.remove(&id);
+                if let Some(m) = self.messages.remove(&id) {
+                    self.cur_bytes = self.cur_bytes.saturating_sub(entry_bytes(&id, &m));
+                }
             }
         }
     }
@@ -410,6 +463,7 @@ impl std::fmt::Debug for MessageCache {
         f.debug_struct("MessageCache")
             .field("windows", &self.windows.len())
             .field("messages", &self.messages.len())
+            .field("bytes", &self.cur_bytes)
             .finish()
     }
 }
@@ -431,7 +485,7 @@ mod mcache_tests {
     /// same bitmask + data round-tripped.
     #[test]
     fn put_then_get_round_trips_the_message() {
-        let mut mc = MessageCache::new(5, 3);
+        let mut mc = MessageCache::new(5, 3, usize::MAX);
         let id = b"msg-1".to_vec();
         let bitmask = vec![0xC0];
         let data = b"hello".to_vec();
@@ -447,7 +501,7 @@ mod mcache_tests {
     /// `get` of an unknown ID returns None — no false positives.
     #[test]
     fn get_unknown_id_returns_none() {
-        let mc = MessageCache::new(5, 3);
+        let mc = MessageCache::new(5, 3, usize::MAX);
         assert!(mc.get(b"never-inserted").is_none());
     }
 
@@ -456,7 +510,7 @@ mod mcache_tests {
     /// gossip flow.
     #[test]
     fn gossip_ids_filtered_by_bitmask() {
-        let mut mc = MessageCache::new(5, 3);
+        let mut mc = MessageCache::new(5, 3, usize::MAX);
         let bm_a = vec![0xC0];
         let bm_b = vec![0x0C];
         mc.put(b"a1".to_vec(), bm_a.clone(), b"x".to_vec(), make_peer());
@@ -481,7 +535,7 @@ mod mcache_tests {
     #[test]
     fn shift_past_history_length_evicts_oldest() {
         let history_length = 3;
-        let mut mc = MessageCache::new(history_length, 2);
+        let mut mc = MessageCache::new(history_length, 2, usize::MAX);
         let bm = vec![0xC0];
 
         let id1 = b"id-1".to_vec();
@@ -508,7 +562,7 @@ mod mcache_tests {
     /// even if still memory-resident.
     #[test]
     fn gossip_ids_scoped_to_history_gossip_window() {
-        let mut mc = MessageCache::new(10, 2);
+        let mut mc = MessageCache::new(10, 2, usize::MAX);
         let bm = vec![0xC0];
 
         // Put one message, then advance windows so it falls outside
@@ -529,11 +583,38 @@ mod mcache_tests {
             "message past history_gossip must NOT be advertised");
     }
 
+    /// REGRESSION (OOM): window-count history does NOT bound bytes. A
+    /// catch-up flood of large subscribed messages within `history_length`
+    /// windows piled up to 14+ GB in `mcache`. The byte budget must evict the
+    /// oldest windows early so total cached bytes stays under `max_bytes`.
+    #[test]
+    fn byte_budget_bounds_total_cached_bytes() {
+        let bm = vec![0xC0];
+        // 10 windows of history, but a 4 KiB byte ceiling.
+        let mut mc = MessageCache::new(10, 3, 4096);
+        // Each "window" gets a 1 KiB message, then we shift. After many
+        // windows the byte total must stay bounded by the budget (+ at most
+        // the current window), NOT grow with history_length.
+        for i in 0..1000u32 {
+            let id = i.to_le_bytes().to_vec();
+            mc.put(id, bm.clone(), vec![0u8; 1024], make_peer());
+            mc.shift();
+        }
+        assert!(
+            mc.byte_len() <= 4096 + 1024,
+            "cached bytes must stay near the budget, got {}",
+            mc.byte_len()
+        );
+        // And the most-recent message is still retained (recency preserved).
+        let last = 999u32.to_le_bytes().to_vec();
+        assert!(mc.get(&last).is_some(), "freshest message must survive");
+    }
+
     /// `put` deposits IDs into the current (latest) window — a
     /// subsequent `get_gossip_ids` (history_gossip ≥ 1) sees them.
     #[test]
     fn put_lands_in_current_window_and_is_gossipable() {
-        let mut mc = MessageCache::new(5, 3);
+        let mut mc = MessageCache::new(5, 3, usize::MAX);
         let bm = vec![0xC0];
         let id = b"fresh".to_vec();
         mc.put(id.clone(), bm.clone(), b"d".to_vec(), make_peer());

--- a/crates/quil-p2p/src/handler.rs
+++ b/crates/quil-p2p/src/handler.rs
@@ -13,10 +13,21 @@ use libp2p::swarm::handler::{
 };
 use libp2p::swarm::Stream;
 use libp2p::StreamProtocol;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::protocol;
 use crate::protocol::pb;
+
+/// Per-connection cap on buffered outbound bytes. A peer whose outbound
+/// substream stalls, never negotiates, or whose socket is backpressured
+/// would otherwise accumulate forwarded RPCs without bound in `send_queue`
+/// — the regular-node OOM (jeprof: 25 GB retained through `handle_rpc`,
+/// held downstream in this queue after the behaviour drained its own
+/// bounded `events` queue). Above this, the oldest `bulk` payloads (and,
+/// as a last resort, the oldest control) are dropped; a peer we can't
+/// write to can't use them anyway, and gossip tolerates loss. 8 MiB
+/// comfortably covers a healthy mesh peer's transient burst.
+const SEND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
 
 /// Messages from the behaviour to the handler.
 #[derive(Debug, Clone)]
@@ -29,6 +40,14 @@ pub struct HandlerIn {
     /// can drop these bulky events under OOM pressure while preserving small
     /// control RPCs (graft/prune/IWANT-request/IHAVE/IDONTWANT/subscribe).
     pub bulk: bool,
+}
+
+/// An outbound RPC buffered in the handler's `send_queue`, tagged with
+/// whether it carries a full message payload so the backpressure cap can
+/// drop bulk traffic first.
+struct QueuedRpc {
+    data: Vec<u8>,
+    bulk: bool,
 }
 
 /// Messages from the handler to the behaviour.
@@ -50,7 +69,9 @@ pub struct BlossomSubHandler {
     /// Outbound substream (writing RPCs to peer).
     outbound: Option<OutboundState>,
     /// Pending outbound RPCs to send.
-    send_queue: VecDeque<Vec<u8>>,
+    send_queue: VecDeque<QueuedRpc>,
+    /// Running total of `send_queue` payload bytes (for the OOM cap).
+    send_queue_bytes: usize,
     /// Pending events to emit to the behaviour.
     events: VecDeque<HandlerOut>,
     /// Whether we've requested an outbound substream.
@@ -81,6 +102,7 @@ impl BlossomSubHandler {
             inbound: None,
             outbound: None,
             send_queue: VecDeque::new(),
+            send_queue_bytes: 0,
             events: VecDeque::new(),
             outbound_requested: false,
             keep_alive: true,
@@ -92,9 +114,64 @@ impl BlossomSubHandler {
     pub fn with_initial_data(protocol: StreamProtocol, initial_rpc: Vec<u8>) -> Self {
         let mut h = Self::new(protocol);
         if !initial_rpc.is_empty() {
-            h.send_queue.push_back(initial_rpc);
+            h.send_queue_bytes += initial_rpc.len();
+            // Subscription hello — control, never shed.
+            h.send_queue.push_back(QueuedRpc {
+                data: initial_rpc,
+                bulk: false,
+            });
         }
         h
+    }
+
+    /// Bound the outbound backlog. When buffered bytes exceed
+    /// `SEND_QUEUE_MAX_BYTES`, drop the OLDEST `bulk` payloads first
+    /// (forwards/publishes — gossip tolerates loss); if the queue is still
+    /// over budget with only control left, drop oldest control too as a hard
+    /// stop. Prevents a stalled/unwritable peer from ballooning memory.
+    fn shed_send_queue(&mut self) {
+        if self.send_queue_bytes <= SEND_QUEUE_MAX_BYTES {
+            return;
+        }
+        let mut dropped = 0usize;
+        let mut dropped_bytes = 0usize;
+
+        // Pass 1: drop oldest bulk entries until under budget.
+        let mut kept: VecDeque<QueuedRpc> = VecDeque::with_capacity(self.send_queue.len());
+        for q in std::mem::take(&mut self.send_queue) {
+            if self.send_queue_bytes > SEND_QUEUE_MAX_BYTES && q.bulk {
+                self.send_queue_bytes -= q.data.len();
+                dropped += 1;
+                dropped_bytes += q.data.len();
+                continue;
+            }
+            kept.push_back(q);
+        }
+        self.send_queue = kept;
+
+        // Pass 2 (rare): queue is all control and still over budget — drop
+        // oldest regardless so memory stays bounded.
+        while self.send_queue_bytes > SEND_QUEUE_MAX_BYTES {
+            match self.send_queue.pop_front() {
+                Some(q) => {
+                    self.send_queue_bytes -= q.data.len();
+                    dropped += 1;
+                    dropped_bytes += q.data.len();
+                }
+                None => break,
+            }
+        }
+
+        if dropped > 0 {
+            warn!(
+                dropped,
+                dropped_bytes,
+                remaining = self.send_queue.len(),
+                remaining_bytes = self.send_queue_bytes,
+                "blossomsub handler: shed outbound backlog — peer not draining \
+                 (OOM backpressure guard)"
+            );
+        }
     }
 
     /// Try to read an RPC from the inbound stream.
@@ -180,16 +257,19 @@ impl BlossomSubHandler {
 
         let OutboundState::Active { stream } = outbound;
 
-        while let Some(data) = self.send_queue.front() {
-            match Pin::new(&mut *stream).poll_write(cx, data) {
+        while let Some(queued) = self.send_queue.front() {
+            match Pin::new(&mut *stream).poll_write(cx, &queued.data) {
                 Poll::Ready(Ok(n)) => {
-                    if n == data.len() {
-                        self.send_queue.pop_front();
+                    if n == queued.data.len() {
+                        if let Some(done) = self.send_queue.pop_front() {
+                            self.send_queue_bytes -= done.data.len();
+                        }
                         debug!(bytes = n, "wrote to outbound");
                     } else {
                         // Partial write — trim what was sent
-                        let remaining = data[n..].to_vec();
-                        *self.send_queue.front_mut().unwrap() = remaining;
+                        let front = self.send_queue.front_mut().unwrap();
+                        front.data = front.data[n..].to_vec();
+                        self.send_queue_bytes -= n;
                         break;
                     }
                 }
@@ -227,7 +307,12 @@ impl ConnectionHandler for BlossomSubHandler {
 
     fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
         debug!(data_len = event.rpc_data.len(), queue_len = self.send_queue.len(), "handler received data from behaviour");
-        self.send_queue.push_back(event.rpc_data);
+        self.send_queue_bytes += event.rpc_data.len();
+        self.send_queue.push_back(QueuedRpc {
+            data: event.rpc_data,
+            bulk: event.bulk,
+        });
+        self.shed_send_queue();
     }
 
     fn on_connection_event(
@@ -299,5 +384,64 @@ impl ConnectionHandler for BlossomSubHandler {
         }
 
         Poll::Pending
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn handler() -> BlossomSubHandler {
+        BlossomSubHandler::new(StreamProtocol::new("/blossomsub/test"))
+    }
+
+    fn feed(h: &mut BlossomSubHandler, len: usize, bulk: bool) {
+        h.on_behaviour_event(HandlerIn {
+            rpc_data: vec![0u8; len],
+            bulk,
+        });
+    }
+
+    /// REGRESSION (OOM): the per-connection outbound `send_queue` had no
+    /// bound. A peer whose outbound stream stalls/never negotiates accumulates
+    /// forwarded payloads forever (jeprof: 25 GB retained through handle_rpc,
+    /// held here). The cap must bound buffered bytes while preserving control.
+    #[test]
+    fn send_queue_capped_drops_bulk_keeps_control() {
+        let mut h = handler();
+        // A few small control RPCs first (must survive).
+        for _ in 0..4 {
+            feed(&mut h, 64, false);
+        }
+        // Flood with 1 MiB bulk forwards — far over the 8 MiB cap.
+        for _ in 0..64 {
+            feed(&mut h, 1024 * 1024, true);
+        }
+        assert!(
+            h.send_queue_bytes <= SEND_QUEUE_MAX_BYTES,
+            "outbound backlog must stay under the cap, got {}",
+            h.send_queue_bytes
+        );
+        // All 4 control RPCs preserved.
+        let control = h.send_queue.iter().filter(|q| !q.bulk).count();
+        assert_eq!(control, 4, "control RPCs must survive backlog shedding");
+        // Accounting matches the actual buffered bytes.
+        let actual: usize = h.send_queue.iter().map(|q| q.data.len()).sum();
+        assert_eq!(actual, h.send_queue_bytes, "byte accounting must stay exact");
+    }
+
+    /// Hard stop: a queue of pure control that still exceeds the cap drops
+    /// oldest entries so memory can't grow without bound even with no bulk.
+    #[test]
+    fn send_queue_hard_caps_even_pure_control() {
+        let mut h = handler();
+        for _ in 0..200 {
+            feed(&mut h, 64 * 1024, false); // 200 × 64 KiB = 12.5 MiB of control
+        }
+        assert!(
+            h.send_queue_bytes <= SEND_QUEUE_MAX_BYTES,
+            "pure-control backlog must still be bounded, got {}",
+            h.send_queue_bytes
+        );
     }
 }

--- a/crates/quil-p2p/src/handler.rs
+++ b/crates/quil-p2p/src/handler.rs
@@ -23,6 +23,12 @@ use crate::protocol::pb;
 pub struct HandlerIn {
     /// Serialized RPC to send to the peer.
     pub rpc_data: Vec<u8>,
+    /// True if `rpc_data` carries a full message payload (a forward, a
+    /// local publish, or an IWANT response). The handler ignores this; it
+    /// exists so the behaviour's backpressure guard (`shed_overflow_events`)
+    /// can drop these bulky events under OOM pressure while preserving small
+    /// control RPCs (graft/prune/IWANT-request/IHAVE/IDONTWANT/subscribe).
+    pub bulk: bool,
 }
 
 /// Messages from the handler to the behaviour.

--- a/crates/quil-p2p/src/handler.rs
+++ b/crates/quil-p2p/src/handler.rs
@@ -29,6 +29,17 @@ use crate::protocol::pb;
 /// comfortably covers a healthy mesh peer's transient burst.
 const SEND_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
 
+/// After this many consecutive shed events with no successful outbound write
+/// in between, the peer is unwritable — its outbound substream never
+/// negotiated (3 failed upgrades, then we give up) or its socket is wedged
+/// (remote not reading). A healthy peer drains at least one RPC between
+/// cap-overflows, which resets this counter, so only a true zero-drain peer
+/// reaches the threshold. When it does, we let the connection close so the
+/// swarm can replace it. Without this, a wedged peer is fed forever and the
+/// master core spins shedding a quarter-million-entry queue instead of doing
+/// useful work. At the observed ~1.5k sheds/s this is ~1.4s of grace.
+const MAX_STUCK_SHEDS: u32 = 2048;
+
 /// Messages from the behaviour to the handler.
 #[derive(Debug, Clone)]
 pub struct HandlerIn {
@@ -72,6 +83,18 @@ pub struct BlossomSubHandler {
     send_queue: VecDeque<QueuedRpc>,
     /// Running total of `send_queue` payload bytes (for the OOM cap).
     send_queue_bytes: usize,
+    /// Of `send_queue_bytes`, how many belong to `bulk` entries. Lets
+    /// `shed_send_queue` skip its O(n) bulk-selective scan entirely when the
+    /// backlog is pure control (the observed flood: 209k × 40-byte RPCs),
+    /// keeping shedding O(dropped) instead of O(queue len) per push.
+    send_queue_bulk_bytes: usize,
+    /// Consecutive shed events since the last successful full outbound write.
+    /// A nonzero value means the peer isn't keeping up; `MAX_STUCK_SHEDS`
+    /// means it isn't draining at all. Reset to 0 on every full write.
+    stuck_sheds: u32,
+    /// Set once the peer is declared unwritable. We stop queuing new sends
+    /// (they could never go out) and let the connection close.
+    closing: bool,
     /// Pending events to emit to the behaviour.
     events: VecDeque<HandlerOut>,
     /// Whether we've requested an outbound substream.
@@ -103,6 +126,9 @@ impl BlossomSubHandler {
             outbound: None,
             send_queue: VecDeque::new(),
             send_queue_bytes: 0,
+            send_queue_bulk_bytes: 0,
+            stuck_sheds: 0,
+            closing: false,
             events: VecDeque::new(),
             outbound_requested: false,
             keep_alive: true,
@@ -136,25 +162,36 @@ impl BlossomSubHandler {
         let mut dropped = 0usize;
         let mut dropped_bytes = 0usize;
 
-        // Pass 1: drop oldest bulk entries until under budget.
-        let mut kept: VecDeque<QueuedRpc> = VecDeque::with_capacity(self.send_queue.len());
-        for q in std::mem::take(&mut self.send_queue) {
-            if self.send_queue_bytes > SEND_QUEUE_MAX_BYTES && q.bulk {
-                self.send_queue_bytes -= q.data.len();
-                dropped += 1;
-                dropped_bytes += q.data.len();
-                continue;
+        // Pass 1: drop oldest bulk entries first (gossip tolerates loss). Skip
+        // the full O(n) scan entirely when the backlog holds no bulk — the
+        // observed pathology is a flood of tiny control RPCs (209k × 40 B),
+        // where rebuilding a quarter-million-entry deque on every push pegs
+        // the master core. With no bulk, fall straight through to the cheap
+        // O(dropped) front-pop below.
+        if self.send_queue_bulk_bytes > 0 {
+            let mut kept: VecDeque<QueuedRpc> = VecDeque::with_capacity(self.send_queue.len());
+            for q in std::mem::take(&mut self.send_queue) {
+                if self.send_queue_bytes > SEND_QUEUE_MAX_BYTES && q.bulk {
+                    self.send_queue_bytes -= q.data.len();
+                    self.send_queue_bulk_bytes -= q.data.len();
+                    dropped += 1;
+                    dropped_bytes += q.data.len();
+                    continue;
+                }
+                kept.push_back(q);
             }
-            kept.push_back(q);
+            self.send_queue = kept;
         }
-        self.send_queue = kept;
 
-        // Pass 2 (rare): queue is all control and still over budget — drop
-        // oldest regardless so memory stays bounded.
+        // Pass 2: still over budget (all control, or bulk exhausted) — drop
+        // oldest regardless so memory stays bounded. O(dropped).
         while self.send_queue_bytes > SEND_QUEUE_MAX_BYTES {
             match self.send_queue.pop_front() {
                 Some(q) => {
                     self.send_queue_bytes -= q.data.len();
+                    if q.bulk {
+                        self.send_queue_bulk_bytes -= q.data.len();
+                    }
                     dropped += 1;
                     dropped_bytes += q.data.len();
                 }
@@ -162,14 +199,41 @@ impl BlossomSubHandler {
             }
         }
 
-        if dropped > 0 {
+        if dropped == 0 {
+            return;
+        }
+
+        self.stuck_sheds = self.stuck_sheds.saturating_add(1);
+
+        // Rate-limited logging: a wedged peer can trigger thousands of sheds
+        // per second. Log once at onset, then once when we give up — not on
+        // every drop.
+        if self.stuck_sheds == 1 {
             warn!(
                 dropped,
                 dropped_bytes,
                 remaining = self.send_queue.len(),
                 remaining_bytes = self.send_queue_bytes,
-                "blossomsub handler: shed outbound backlog — peer not draining \
-                 (OOM backpressure guard)"
+                "blossomsub handler: outbound backlog over cap — peer draining \
+                 slowly (backpressure guard)"
+            );
+        }
+
+        // No outbound progress across many sheds → the peer is unwritable.
+        // Stop feeding it and let the connection close; the swarm/mesh will
+        // graft a replacement. Free the doomed backlog immediately.
+        if self.stuck_sheds >= MAX_STUCK_SHEDS && !self.closing {
+            self.closing = true;
+            self.keep_alive = false;
+            let abandoned = self.send_queue.len();
+            self.send_queue.clear();
+            self.send_queue_bytes = 0;
+            self.send_queue_bulk_bytes = 0;
+            warn!(
+                stuck_sheds = self.stuck_sheds,
+                abandoned,
+                "blossomsub handler: peer unwritable (zero outbound drain) — \
+                 closing connection so the swarm can replace it"
             );
         }
     }
@@ -263,13 +327,22 @@ impl BlossomSubHandler {
                     if n == queued.data.len() {
                         if let Some(done) = self.send_queue.pop_front() {
                             self.send_queue_bytes -= done.data.len();
+                            if done.bulk {
+                                self.send_queue_bulk_bytes -= done.data.len();
+                            }
                         }
+                        // The peer accepted a full RPC — it's draining, so it
+                        // isn't the wedged/zero-drain case. Reset the guard.
+                        self.stuck_sheds = 0;
                         debug!(bytes = n, "wrote to outbound");
                     } else {
                         // Partial write — trim what was sent
                         let front = self.send_queue.front_mut().unwrap();
                         front.data = front.data[n..].to_vec();
                         self.send_queue_bytes -= n;
+                        if front.bulk {
+                            self.send_queue_bulk_bytes -= n;
+                        }
                         break;
                     }
                 }
@@ -306,8 +379,16 @@ impl ConnectionHandler for BlossomSubHandler {
     }
 
     fn on_behaviour_event(&mut self, event: Self::FromBehaviour) {
+        if self.closing {
+            // Peer declared unwritable; the connection is winding down.
+            // Queuing more would only be shed — drop it now.
+            return;
+        }
         debug!(data_len = event.rpc_data.len(), queue_len = self.send_queue.len(), "handler received data from behaviour");
         self.send_queue_bytes += event.rpc_data.len();
+        if event.bulk {
+            self.send_queue_bulk_bytes += event.rpc_data.len();
+        }
         self.send_queue.push_back(QueuedRpc {
             data: event.rpc_data,
             bulk: event.bulk,
@@ -349,8 +430,16 @@ impl ConnectionHandler for BlossomSubHandler {
                     debug!(retry = self.outbound_retries, "outbound BlossomSub upgrade failed, will retry");
                     self.outbound_requested = false;
                 } else {
-                    debug!("outbound BlossomSub upgrade failed 3 times, giving up");
-                    // Keep outbound_requested=true to prevent more retries
+                    // Outbound never negotiated after 3 tries: we can never
+                    // send to this peer. Don't sit on it as a zombie with a
+                    // growing send_queue — close so the swarm can re-dial /
+                    // graft a replacement.
+                    debug!("outbound BlossomSub upgrade failed 3 times, giving up — closing");
+                    self.closing = true;
+                    self.keep_alive = false;
+                    self.send_queue.clear();
+                    self.send_queue_bytes = 0;
+                    self.send_queue_bulk_bytes = 0;
                 }
             }
             _ => {}
@@ -443,5 +532,46 @@ mod tests {
             "pure-control backlog must still be bounded, got {}",
             h.send_queue_bytes
         );
+    }
+
+    /// REGRESSION (CPU peg + warning storm): a peer that never drains (no
+    /// outbound write ever resets `stuck_sheds`) must eventually be declared
+    /// unwritable so the connection closes — otherwise the master core spins
+    /// shedding a quarter-million-entry queue forever (observed: 6k warns in
+    /// 4s, zero useful work).
+    #[test]
+    fn unwritable_peer_closes_after_repeated_sheds() {
+        let mut h = handler();
+        // No outbound stream is ever negotiated, so nothing drains. Each
+        // over-cap push triggers a shed. Push enough small control RPCs to
+        // exceed the cap, then keep pushing past MAX_STUCK_SHEDS.
+        let entry = 64 * 1024; // 64 KiB; ~128 fill the 8 MiB cap
+        for _ in 0..(128 + MAX_STUCK_SHEDS as usize + 8) {
+            feed(&mut h, entry, false);
+            if h.closing {
+                break;
+            }
+        }
+        assert!(h.closing, "a zero-drain peer must be declared unwritable");
+        assert!(!h.keep_alive, "closing handler must drop keep_alive");
+        // Backlog freed on close; further sends are dropped, not queued.
+        assert_eq!(h.send_queue_bytes, 0);
+        assert!(h.send_queue.is_empty());
+        feed(&mut h, entry, false);
+        assert!(h.send_queue.is_empty(), "closing handler must not re-queue");
+    }
+
+    /// A peer that drains keeps the connection: a successful write resets the
+    /// stuck counter, so transient over-cap bursts never trip the close path.
+    #[test]
+    fn draining_peer_is_not_closed() {
+        let mut h = handler();
+        for _ in 0..200 {
+            feed(&mut h, 64 * 1024, false);
+            // Simulate the peer accepting a full RPC between pushes.
+            h.stuck_sheds = 0;
+        }
+        assert!(!h.closing, "a draining peer must not be closed");
+        assert!(h.send_queue_bytes <= SEND_QUEUE_MAX_BYTES);
     }
 }

--- a/crates/quil-p2p/src/lib.rs
+++ b/crates/quil-p2p/src/lib.rs
@@ -82,6 +82,16 @@ pub mod params {
     /// clustering (a couple of legitimate co-located peers) through
     /// without bias; 1 is the strictest setting.
     pub const MESH_PEERS_PER_SUBNET: usize = 2;
+    /// Hard cap on the total bytes of message payloads held in the
+    /// IHAVE/IWANT message cache (`MessageCache`). The cache retains
+    /// `HISTORY_LENGTH` (24) windows × `HEARTBEAT_INTERVAL` (700ms) ≈ 17s
+    /// of *subscribed* traffic, cloning each message's full payload. Under
+    /// a catch-up flood of large consensus frames that window alone reached
+    /// 14+ GB (jeprof: dominant stack through `on_connection_handler_event`
+    /// → `handle_rpc` → `mcache.put`). Window-count bounding does not bound
+    /// bytes; this does. 512 MiB is far more than gossip recovery needs
+    /// while keeping the cache from driving OOM.
+    pub const MCACHE_MAX_BYTES: usize = 512 * 1024 * 1024;
 }
 
 /// Runtime-configurable BlossomSub parameters. Behaviour holds an
@@ -117,6 +127,10 @@ pub struct BlossomsubParams {
     /// Eclipse-resistance: see [`params::MESH_PEERS_PER_SUBNET`].
     /// `0` disables the check.
     pub mesh_peers_per_subnet: usize,
+    /// Hard byte cap on the IHAVE/IWANT message cache. See
+    /// [`params::MCACHE_MAX_BYTES`]. Bounds memory under catch-up floods
+    /// that window-count history alone cannot.
+    pub mcache_max_bytes: usize,
 }
 
 impl Default for BlossomsubParams {
@@ -140,6 +154,7 @@ impl Default for BlossomsubParams {
             idont_want_message_threshold: params::IDONT_WANT_MESSAGE_THRESHOLD,
             max_idont_want_messages: 5000,
             mesh_peers_per_subnet: params::MESH_PEERS_PER_SUBNET,
+            mcache_max_bytes: params::MCACHE_MAX_BYTES,
         }
     }
 }
@@ -198,6 +213,9 @@ impl BlossomsubParams {
             // post-build if they need to. Default protects against
             // single-/24 eclipse on every node.
             mesh_peers_per_subnet: d.mesh_peers_per_subnet,
+            // No P2PConfig field yet — defaults to a 512 MiB ceiling,
+            // tunable via `set_params` post-build.
+            mcache_max_bytes: d.mcache_max_bytes,
         }
     }
 }

--- a/docker/Dockerfile.source
+++ b/docker/Dockerfile.source
@@ -286,6 +286,14 @@ COPY --from=gen-rust /out/ /opt/ceremonyclient/target/release/
 # Stage: build-node
 # -----------------------------------------------------------------------------
 FROM build-context AS build-node
+# Emit frame pointers across the whole Rust node binary (quil-node + its
+# deps, including quil-p2p/libp2p). Release builds otherwise omit them, so
+# jemalloc/jeprof can't unwind allocation stacks and collapse every sample
+# onto `prof_backtrace_impl` / a single `on_connection_handler_event` frame,
+# hiding which structure actually leaks. The ~1-2% perf cost is acceptable
+# for a profilable production binary. No .cargo/config rustflags exist to
+# merge with, and build.sh leaves RUSTFLAGS untouched, so cargo inherits it.
+ENV RUSTFLAGS="-C force-frame-pointers=yes"
 COPY ./node /opt/ceremonyclient/node
 WORKDIR /opt/ceremonyclient/node
 # build.sh compiles the Rust `quil-node` crate in release mode and


### PR DESCRIPTION
**Problem**

quil-node 2.1.0.25 OOMed at ~28–40 GB RSS. jeprof put ~99% of retained bytes under BlossomSub::on_connection_handler_event → handle_rpc. The node runs the gossip swarm on the master core; on a degraded network (peers/archives we can't write to) every buffer on the inbound→forward path grew without bound.

**Root causes & fixes**

Three separate unbounded structures, all on the same path, all now bounded — plus two follow-on problems the first fixes exposed:

1. behaviour.events (VecDeque) — the existing OOM guard only shed Message deliveries, but each inbound message also enqueues up to D NotifyHandler forwards; a relay (forwarding a bitmask it isn't subscribed to) produced only forwards, so the guard found nothing to drop and the queue grew unbounded. Tagged payload-carrying events with a bulk flag on HandlerIn and made the shed guard drop bulk forwards too.
2. mcache (MessageCache) — bounded only by window count, not bytes; a catch-up flood of large frames reached 14+ GB. Added a 512 MiB byte budget (evict_to_budget, never drops the current window).
3. handler.send_queue (per-connection) — completely unbounded. After the behaviour drains its bounded queue via NotifyHandler, payloads land here; a peer whose outbound stalls/never negotiates accumulates forever (the 25 GB the symbolized profile localized here). Added an 8 MiB/connection cap, shedding bulk first, control as a hard stop.

Re-running with the caps in place bounded memory (events ~180k capped, mcache ~1.7 MB) but surfaced two more issues, now fixed in the same branch:

4. CPU peg (no useful work): the observed flood was 209k × 40-byte control RPCs to a single non-draining peer. shed_send_queue rebuilt the entire VecDeque on every push even with nothing bulk to drop — O(n²) over the flood, pegging the master core. Now track send_queue_bulk_bytes and skip the scan for pure-control backlogs (O(dropped) front-pop).
5. Zombie connections: a peer whose outbound never negotiated (3 failed upgrades) or whose socket is wedged kept keep_alive=true and was fed forever. Now a successful write resets a stuck counter; after MAX_STUCK_SHEDS (2048) consecutive sheds with zero drain — or on permanent outbound-upgrade failure — the peer is declared unwritable, keep_alive drops, the backlog is freed, and the swarm closes/re-dials so the mesh grafts a replacement. Shed warning is rate-limited (onset + give-up, not per-drop).

**Tooling**

- docker/Dockerfile.source: RUSTFLAGS="-C force-frame-pointers=yes" in the node build stage, so jeprof can symbolize PIE stacks (this is what made root-causing #3 possible).

**Testing**

- cargo test -p quil-p2p: 185 pass (added: send_queue_capped_drops_bulk_keeps_control, send_queue_hard_caps_even_pure_control, unwritable_peer_closes_after_repeated_sheds, draining_peer_is_not_closed, byte_budget_bounds_total_cached_bytes, plus the bulk-forward shed regression).
- A blossomsub memory gauge (debug, every ~22s) reports events/mcache_bytes/seen/pending_iwants/peer_subs; warns when bulk buffers are elevated.

**What to watch after deploy**

Instead of unbounded RSS + a warning storm: occasional shed-onset warns, then peer unwritable … closing connection as dead peers are reaped, with the master core freed for consensus work. If gossip still can't progress, the bottleneck is upstream connectivity, not node memory/CPU.

🤖 Generated with Claude Code