### PR TITLE
Add dockerized Rust test task; trim docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+# Build output — the image compiles fresh in-container; host target/ is never
+# needed (target/release is repopulated from the gen-rust stage), and it's
+# ~10 GB of pure context bloat.
+target/
+**/target/
+
+# Version control metadata — not needed by any build stage.
+.git/
+
+# Node/qclient build outputs (the Dockerfile produces its own).
+node/build/
+client/build/
+conntest/build/
+
+# Local profiling / log artifacts (jemalloc heaps, per-core logs, copied
+# binaries). Tens of GB; never an input to the build.
+.log/
+jeprof/
+*.heap
+jeprof.*
+
+# Editor / OS noise.
+.DS_Store

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -134,6 +134,38 @@ tasks:
     cmds:
       - docker build --ulimit stack=-1:-1 --platform linux/amd64 -f docker/Dockerfile.source --output node/build/amd64_linux --target=node .
 
+  test_rust_amd64_linux:
+    desc: >-
+      Run the Rust workspace tests inside the AMD64 Linux build image — the
+      same environment that builds the node, carrying the GMP/FLINT/EMP native
+      deps that classgroup, bls48581, and vdf need to compile (which a bare
+      `cargo test` on a host lacking them cannot). Mirrors CI's `cargo nextest
+      run`, including the .nextest.toml skip-filter. Narrow scope by appending
+      args after `--`, e.g. `task test_rust_amd64_linux -- -p quil-engine` or
+      `task test_rust_amd64_linux -- -E 'test(materialize)'`; with no args it
+      runs the whole workspace. The cargo registry/git caches persist in named
+      volumes, but the compile target dir does not, so expect a cold compile
+      on the first run after a source change.
+    vars:
+      NEXTEST_ARGS: '{{.CLI_ARGS | default "--workspace --exclude channelwasm"}}'
+    cmds:
+      # test-context = build-context (full source + native deps) plus the node/
+      # tree that several crates embed fixtures from. Layers below build-context
+      # are already cached if the node image was built, so this is cheap.
+      - docker build --ulimit stack=-1:-1 --platform linux/amd64 -f docker/Dockerfile.source --target test-context -t quilibrium-rust-test:latest .
+      # The target volume persists compiled artifacts across runs so a long
+      # cold compile resumes instead of restarting; it starts empty and is
+      # populated from source exactly as CI does (CI has no prebuilt artifacts),
+      # so it safely shadows the image's gen-rust release .a files.
+      - >-
+        docker run --rm --ulimit stack=-1:-1 --platform linux/amd64
+        -v quilibrium-cargo-registry:/root/.cargo/registry
+        -v quilibrium-cargo-git:/root/.cargo/git
+        -v quilibrium-cargo-target:/opt/ceremonyclient/target
+        -w /opt/ceremonyclient quilibrium-rust-test:latest
+        bash -c 'curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C /usr/local/bin &&
+        cargo nextest run --locked --no-fail-fast --config-file .nextest.toml {{.NEXTEST_ARGS}}'
+
   build_conntest_amd64_linux:
     desc: Build the Quilibrium node connection test binary for AMD64 Linux. Outputs to conntest/build.
     cmds:

--- a/docker/Dockerfile.source
+++ b/docker/Dockerfile.source
@@ -283,6 +283,19 @@ COPY --from=gen-rust /opt/ceremonyclient/bulletproofs /opt/ceremonyclient/bullet
 COPY --from=gen-rust /out/ /opt/ceremonyclient/target/release/
 
 # -----------------------------------------------------------------------------
+# Stage: test-context
+# build-context plus the node/ tree (which build-context excludes). Several
+# Rust crates embed fixtures from node/ at compile time — e.g.
+# quil-execution's seniority_compat.rs does `include_str!(
+# "../../../node/execution/intrinsics/global/compat/*_retro.json")` — so the
+# workspace tests can't even compile without it. This stage exists purely for
+# the `test_rust_amd64_linux` task; it does NOT build the node binary (no
+# build.sh), so it's a cheap COPY on top of build-context.
+# -----------------------------------------------------------------------------
+FROM build-context AS test-context
+COPY ./node /opt/ceremonyclient/node
+
+# -----------------------------------------------------------------------------
 # Stage: build-node
 # -----------------------------------------------------------------------------
 FROM build-context AS build-node


### PR DESCRIPTION
Make the native-deps-dependent Rust tests runnable without a local GMP/FLINT/EMP/classgroup toolchain, mirroring CI:

- Taskfile: `test_rust_amd64_linux` runs `cargo nextest run` (with the .nextest.toml skip-filter) inside the Linux build image. Takes scoping args, e.g. `task test_rust_amd64_linux -- -p quil-engine`. Caches cargo registry/git/target in named volumes so a long cold compile resumes across runs rather than restarting.
- Dockerfile.source: new `test-context` stage = build-context + node/. Several crates embed fixtures from node/ at compile time (e.g. quil-execution's seniority_compat.rs include_str!s node/execution/intrinsics/global/compat/*_retro.json), which build-context excludes, so the workspace tests can't compile there.
- .dockerignore (new): exclude target/, .log/, jeprof/, .git/, and build outputs. The Dockerfile's `COPY . .` was shipping ~8 GB of these into the build context every build.